### PR TITLE
Fix missing newlines after lists and quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Render text in svg images.
 - Fixed erroneous newline after images.
+- Fixed missing newline after lists and quotes.
 
 ## 0.4.0 - 2022-08-25
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -673,6 +673,7 @@ impl CommonMarkViewerInternal {
             pulldown_cmark::Tag::BlockQuote => {
                 self.text_style.quote = false;
                 ui.add(egui::Separator::default().horizontal());
+                newline(ui);
             }
             pulldown_cmark::Tag::CodeBlock(_) => {
                 self.end_code_block(ui, cache, options, max_width);
@@ -681,6 +682,7 @@ impl CommonMarkViewerInternal {
                 self.indentation -= 1;
                 if self.indentation == -1 {
                     newline(ui);
+                    self.should_insert_newline = true;
                 }
             }
             pulldown_cmark::Tag::Item => {}


### PR DESCRIPTION
Turned out to be quite "simple" after all.

Closes #2 