### PR TITLE
Added scroll rendering

### DIFF
--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -1,0 +1,73 @@
+//! Make sure to run this example from the repo directory and not the example
+//! directory. To see all the features in full effect, run this example with
+//! `cargo r --example scroll --all-features`
+//! Add `light` or `dark` to the end of the command to specify theme. Default
+//! is light. `cargo r --example scroll --all-features dark`
+
+use eframe::egui;
+use egui_commonmark::*;
+
+struct App {
+    cache: CommonMarkCache,
+}
+
+impl eframe::App for App {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        let mut text = r#"# Commonmark Viewer Example
+        This is a fairly large markdown file showcasing scroll.
+                    "#
+        .to_string();
+
+        let repeating = r#"
+This section will be repeated
+
+```rs
+let mut vec = Vec::new();
+vec.push(5);
+```
+ 
+# Plans
+* Make a sandwich
+* Bake a cake
+* Conquer the world
+        "#;
+        text += &repeating.repeat(1024);
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            CommonMarkViewer::new("viewer")
+                .max_image_width(Some(512))
+                .show_scrollable(ui, &mut self.cache, &text);
+        });
+    }
+}
+
+fn main() {
+    let mut args = std::env::args();
+    args.next();
+    let use_dark_theme = if let Some(theme) = args.next() {
+        if theme == "light" {
+            false
+        } else {
+            theme == "dark"
+        }
+    } else {
+        false
+    };
+
+    eframe::run_native(
+        "Markdown viewer",
+        eframe::NativeOptions::default(),
+        Box::new(move |cc| {
+            cc.egui_ctx.set_visuals(if use_dark_theme {
+                egui::Visuals::dark()
+            } else {
+                egui::Visuals::light()
+            });
+
+            Box::new(App {
+                cache: CommonMarkCache::default(),
+            })
+        }),
+    )
+    .unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! ```
 
-use egui::{self, Id, RichText, Sense, TextStyle, Ui};
+use egui::{self, Id, Pos2, RichText, Sense, TextStyle, Ui, Vec2};
 use egui::{ColorImage, TextureHandle};
 use pulldown_cmark::{CowStr, HeadingLevel};
 use std::collections::hash_map::Entry;
@@ -86,6 +86,8 @@ pub struct CommonMarkCache {
     #[cfg(feature = "syntax_highlighting")]
     ts: ThemeSet,
     link_hooks: HashMap<String, bool>,
+    page_size: Option<Vec2>,
+    split_points: Vec<(usize, Pos2, Pos2)>,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -98,6 +100,8 @@ impl Default for CommonMarkCache {
             #[cfg(feature = "syntax_highlighting")]
             ts: ThemeSet::load_defaults(),
             link_hooks: HashMap::new(),
+            page_size: None,
+            split_points: Vec::new(),
         }
     }
 }
@@ -321,7 +325,20 @@ impl CommonMarkViewer {
 
     pub fn show(self, ui: &mut egui::Ui, cache: &mut CommonMarkCache, text: &str) {
         cache.deactivate_link_hooks();
-        CommonMarkViewerInternal::new(self.source_id).show(ui, cache, &self.options, text);
+        CommonMarkViewerInternal::new(self.source_id).show(ui, cache, &self.options, text, false);
+    }
+
+    /// Shows markdown file inside a ScrollArea
+    /// This function is much more performant than just calling show inside a ScrollArea,
+    /// because it only renders elements that are visible.
+    pub fn show_scrollable(self, ui: &mut egui::Ui, cache: &mut CommonMarkCache, text: &str) {
+        cache.deactivate_link_hooks();
+        CommonMarkViewerInternal::new(self.source_id).show_scrollable(
+            ui,
+            cache,
+            &self.options,
+            text,
+        );
     }
 }
 
@@ -387,6 +404,7 @@ impl CommonMarkViewerInternal {
         cache: &mut CommonMarkCache,
         options: &CommonMarkOptions,
         text: &str,
+        populate_split_points: bool,
     ) {
         let max_image_width = cache.max_image_width(options);
         let available_width = ui.available_width();
@@ -414,27 +432,121 @@ impl CommonMarkViewerInternal {
                 | Options::ENABLE_TASKLISTS
                 | Options::ENABLE_STRIKETHROUGH
                 | Options::ENABLE_FOOTNOTES;
-            let mut events = pulldown_cmark::Parser::new_ext(text, parser_options);
+            let mut events = pulldown_cmark::Parser::new_ext(text, parser_options).enumerate();
 
-            while let Some(e) = events.next() {
+            while let Some((index, e)) = events.next() {
+                let start_position = ui.next_widget_position();
+                let is_element_end = matches!(e, pulldown_cmark::Event::End(_));
+                let should_add_split_point = self.indentation == -1 && is_element_end;
+
                 self.event(ui, e, cache, options, max_width);
 
                 self.fenced_code_block(&mut events, max_width, cache, options, ui);
                 self.table(&mut events, cache, options, ui, max_width);
+
+                if populate_split_points {
+                    let end_position = ui.next_widget_position();
+
+                    let split_point_exists = cache.split_points.iter().any(|(i, _, _)| *i == index);
+
+                    if should_add_split_point && !split_point_exists {
+                        cache
+                            .split_points
+                            .push((index, start_position, end_position));
+                    }
+                }
             }
+
+            cache.page_size = Some(ui.next_widget_position().to_vec2());
+        });
+    }
+
+    pub fn show_scrollable(
+        &mut self,
+        ui: &mut egui::Ui,
+        cache: &mut CommonMarkCache,
+        options: &CommonMarkOptions,
+        text: &str,
+    ) {
+        let Some(page_size) = cache.page_size else {
+            self.show(ui, cache, options, text, true);
+            return;
+        };
+
+        use pulldown_cmark::Options;
+        let parser_options = Options::ENABLE_TABLES
+            | Options::ENABLE_TASKLISTS
+            | Options::ENABLE_STRIKETHROUGH
+            | Options::ENABLE_FOOTNOTES;
+        let events = pulldown_cmark::Parser::new_ext(text, parser_options).collect::<Vec<_>>();
+
+        let num_rows = events.len();
+
+        egui::ScrollArea::vertical().show_viewport(ui, |ui, viewport| {
+            ui.set_height(page_size.y);
+            let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
+
+            let max_image_width = cache.max_image_width(options);
+            let available_width = ui.available_width();
+
+            let max_width = max_image_width.max(available_width);
+            let max_width = if let Some(default_width) = options.default_width {
+                if default_width as f32 > max_width {
+                    default_width as f32
+                } else {
+                    max_width
+                }
+            } else {
+                max_width
+            };
+
+            ui.allocate_ui_with_layout(egui::vec2(max_width, 0.0), layout, |ui| {
+                // finding the first element that's not in the viewport anymore
+                let (first_event_index, _, first_end_position) = cache
+                    .split_points
+                    .iter()
+                    .filter(|(_, _, end_position)| end_position.y < viewport.min.y)
+                    .nth_back(1)
+                    .copied()
+                    .unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
+
+                // finding the last element that's just outside the viewport
+                let last_event_index = cache
+                    .split_points
+                    .iter()
+                    .filter(|(_, start_position, _)| start_position.y > viewport.max.y)
+                    .nth(1)
+                    .map(|(index, _, _)| *index)
+                    .unwrap_or(num_rows);
+
+                ui.allocate_space(first_end_position.to_vec2());
+
+                // only rendering the elements that are inside the viewport
+                let mut events = events
+                    .into_iter()
+                    .enumerate()
+                    .skip(first_event_index)
+                    .take(last_event_index - first_event_index);
+
+                while let Some((_, e)) = events.next() {
+                    self.event(ui, e, cache, options, max_width);
+                    self.fenced_code_block(&mut events, max_width, cache, options, ui);
+                    self.table(&mut events, cache, options, ui, max_width);
+                }
+            });
         });
     }
 
     fn fenced_code_block<'e>(
         &mut self,
-        events: &mut impl Iterator<Item = pulldown_cmark::Event<'e>>,
+        events: &mut impl Iterator<Item = (usize, pulldown_cmark::Event<'e>)>,
         max_width: f32,
         cache: &mut CommonMarkCache,
         options: &CommonMarkOptions,
         ui: &mut Ui,
     ) {
         while self.fenced_code_block_lang.is_some() {
-            if let Some(e) = events.next() {
+            if let Some((_, e)) = events.next() {
                 self.event(ui, e, cache, options, max_width);
             } else {
                 break;
@@ -444,7 +556,7 @@ impl CommonMarkViewerInternal {
 
     fn table<'e>(
         &mut self,
-        events: &mut impl Iterator<Item = pulldown_cmark::Event<'e>>,
+        events: &mut impl Iterator<Item = (usize, pulldown_cmark::Event<'e>)>,
         cache: &mut CommonMarkCache,
         options: &CommonMarkOptions,
         ui: &mut Ui,
@@ -457,7 +569,7 @@ impl CommonMarkViewerInternal {
                 self.curr_table += 1;
                 egui::Grid::new(id).striped(true).show(ui, |ui| {
                     while self.is_table {
-                        if let Some(e) = events.next() {
+                        if let Some((_, e)) = events.next() {
                             self.should_insert_newline = false;
                             self.event(ui, e, cache, options, max_width);
                         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ pub struct CommonMarkCache {
     #[cfg(feature = "syntax_highlighting")]
     ts: ThemeSet,
     link_hooks: HashMap<String, bool>,
+    available_size: Vec2,
     page_size: Option<Vec2>,
     split_points: Vec<(usize, Pos2, Pos2)>,
 }
@@ -100,6 +101,7 @@ impl Default for CommonMarkCache {
             #[cfg(feature = "syntax_highlighting")]
             ts: ThemeSet::load_defaults(),
             link_hooks: HashMap::new(),
+            available_size: Vec2::ZERO,
             page_size: None,
             split_points: Vec::new(),
         }
@@ -406,6 +408,8 @@ impl CommonMarkViewerInternal {
         text: &str,
         populate_split_points: bool,
     ) {
+        cache.available_size = ui.available_size();
+
         let max_image_width = cache.max_image_width(options);
         let available_width = ui.available_width();
 
@@ -468,6 +472,8 @@ impl CommonMarkViewerInternal {
         options: &CommonMarkOptions,
         text: &str,
     ) {
+        let available_size = ui.available_size();
+
         let Some(page_size) = cache.page_size else {
             self.show(ui, cache, options, text, true);
             return;
@@ -535,6 +541,11 @@ impl CommonMarkViewerInternal {
                 }
             });
         });
+
+        // Forcing full re-render to repopulate split points for the new size
+        if available_size != cache.available_size {
+            cache.page_size = None;
+        }
     }
 
     fn fenced_code_block<'e>(


### PR DESCRIPTION
This adds a function that allows rendering the file in a scrollable area, which renders only the components that are visible. It allows for much larger markdown files to be loaded without any performance penalty.