### PR TITLE
Show image loading errors to the user

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,14 @@ include = ["src/*.rs", "LICENSE-MIT", "LICENSE-APACHE", "Cargo.toml"]
 
 [dependencies]
 egui = { git = "https://github.com/emilk/egui", rev = "2c7c598" }
-pulldown-cmark = { version = "0.9.3", default-features = false }
 image = { version = "0.24", default-features = false, features = ["png"] }
+parking_lot = "0.12"
+poll-promise = "0.3"
+pulldown-cmark = { version = "0.9.3", default-features = false }
 
-syntect = { version = "5.0.0", optional = true, default-features = false, features = ["default-fancy"] }
+syntect = { version = "5.0.0", optional = true, default-features = false, features = [
+    "default-fancy",
+] }
 
 resvg = { version = "0.35.0", optional = true }
 usvg = { version = "0.35.0", optional = true }

--- a/src/fetch_data.rs
+++ b/src/fetch_data.rs
@@ -1,0 +1,33 @@
+use crate::ImageHashMap;
+
+#[cfg(not(feature = "fetch"))]
+pub fn get_image_data(path: &str, _ctx: &egui::Context, _images: ImageHashMap) -> Option<Vec<u8>> {
+    get_image_data_from_file(path)
+}
+
+#[cfg(feature = "fetch")]
+fn get_image_data(path: &str, ctx: &egui::Context, images: ImageHashMap) -> Option<Vec<u8>> {
+    let url = url::Url::parse(path);
+    if url.is_ok() {
+        let ctx2 = ctx.clone();
+        let path = path.to_owned();
+        ehttp::fetch(ehttp::Request::get(&path), move |r| {
+            if let Ok(r) = r {
+                let data = r.bytes;
+                if let Some(handle) = parse_image(&ctx2, &path, &data) {
+                    // we only update if the image was loaded properly
+                    *images.lock().unwrap().get_mut(&path).unwrap() = Some(handle);
+                    ctx2.request_repaint();
+                }
+            }
+        });
+
+        None
+    } else {
+        get_image_data_from_file(path)
+    }
+}
+
+fn get_image_data_from_file(url: &str) -> Option<Vec<u8>> {
+    std::fs::read(url).ok()
+}

--- a/src/image_loading.rs
+++ b/src/image_loading.rs
@@ -1,0 +1,45 @@
+use egui::ColorImage;
+
+pub fn load_image(data: &[u8]) -> Option<ColorImage> {
+    try_load_image(data).ok().or_else(|| try_render_svg(data))
+}
+
+fn try_load_image(data: &[u8]) -> image::ImageResult<ColorImage> {
+    let image = image::load_from_memory(data)?;
+    let image_buffer = image.to_rgba8();
+    let size = [image.width() as usize, image.height() as usize];
+    let pixels = image_buffer.as_flat_samples();
+
+    Ok(ColorImage::from_rgba_unmultiplied(size, pixels.as_slice()))
+}
+
+#[cfg(not(feature = "svg"))]
+fn try_render_svg(_data: &[u8]) -> Option<ColorImage> {
+    None
+}
+
+#[cfg(feature = "svg")]
+fn try_render_svg(data: &[u8]) -> Option<ColorImage> {
+    use resvg::tiny_skia;
+    use usvg::{TreeParsing, TreeTextToPath};
+
+    let tree = {
+        let options = usvg::Options::default();
+        let mut fontdb = usvg::fontdb::Database::new();
+        fontdb.load_system_fonts();
+
+        let mut tree = usvg::Tree::from_data(data, &options).ok()?;
+        tree.convert_text(&fontdb);
+        resvg::Tree::from_usvg(&tree)
+    };
+
+    let size = tree.size.to_int_size();
+
+    let mut pixmap = tiny_skia::Pixmap::new(size.width(), size.height())?;
+    tree.render(tiny_skia::Transform::default(), &mut pixmap.as_mut());
+
+    Some(ColorImage::from_rgba_unmultiplied(
+        [pixmap.width() as usize, pixmap.height() as usize],
+        &pixmap.take(),
+    ))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ impl CommonMarkCache {
     }
 
     /// If the user clicks on a link in the markdown render that has `name` as a link. The hook
-    /// specified with this method will be set to true. It's status can be aquired
+    /// specified with this method will be set to true. It's status can be acquired
     /// with [`get_link_hook`](Self::get_link_hook). Be aware that all hooks are reset once
     /// [`CommonMarkViewer::show`] gets called
     pub fn add_link_hook<S: Into<String>>(&mut self, name: S) {
@@ -491,7 +491,7 @@ impl CommonMarkViewerInternal {
 }
 
 impl CommonMarkViewerInternal {
-    /// Be aware that this aquires egui::Context internally.
+    /// Be aware that this acquires egui::Context internally.
     pub fn show(
         &mut self,
         ui: &mut egui::Ui,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,11 +47,11 @@ struct ScrollableCache {
 }
 
 #[derive(Default)]
-struct ImaheHandleCache {
+struct ImageHandleCache {
     cache: HashMap<String, Promise<Result<TextureHandle, String>>>,
 }
 
-impl ImaheHandleCache {
+impl ImageHandleCache {
     fn clear(&mut self) {
         self.cache.clear();
     }
@@ -86,13 +86,13 @@ impl ImaheHandleCache {
     }
 }
 
-impl ImaheHandleCache {}
+impl ImageHandleCache {}
 
 /// A cache used for storing content such as images.
 pub struct CommonMarkCache {
     // Everything stored here must take into account that the cache is for multiple
     // CommonMarkviewers with different source_ids.
-    images: Arc<Mutex<ImaheHandleCache>>,
+    images: Arc<Mutex<ImageHandleCache>>,
 
     #[cfg(feature = "syntax_highlighting")]
     ps: SyntaxSet,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,10 @@
 //!
 //! ```
 
+mod image_loading;
+
+use egui::TextureHandle;
 use egui::{self, epaint, Id, NumExt, Pos2, RichText, Sense, TextStyle, Ui, Vec2};
-use egui::{ColorImage, TextureHandle};
 use pulldown_cmark::{CowStr, HeadingLevel, Options};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -33,46 +35,6 @@ use syntect::{
     parsing::{SyntaxDefinition, SyntaxSet},
     util::LinesWithEndings,
 };
-
-fn load_image(data: &[u8]) -> image::ImageResult<ColorImage> {
-    let image = image::load_from_memory(data)?;
-    let image_buffer = image.to_rgba8();
-    let size = [image.width() as usize, image.height() as usize];
-    let pixels = image_buffer.as_flat_samples();
-
-    Ok(ColorImage::from_rgba_unmultiplied(size, pixels.as_slice()))
-}
-
-#[cfg(not(feature = "svg"))]
-fn try_render_svg(_data: &[u8]) -> Option<ColorImage> {
-    None
-}
-
-#[cfg(feature = "svg")]
-fn try_render_svg(data: &[u8]) -> Option<ColorImage> {
-    use resvg::tiny_skia;
-    use usvg::{TreeParsing, TreeTextToPath};
-
-    let tree = {
-        let options = usvg::Options::default();
-        let mut fontdb = usvg::fontdb::Database::new();
-        fontdb.load_system_fonts();
-
-        let mut tree = usvg::Tree::from_data(data, &options).ok()?;
-        tree.convert_text(&fontdb);
-        resvg::Tree::from_usvg(&tree)
-    };
-
-    let size = tree.size.to_int_size();
-
-    let mut pixmap = tiny_skia::Pixmap::new(size.width(), size.height())?;
-    tree.render(tiny_skia::Transform::default(), &mut pixmap.as_mut());
-
-    Some(ColorImage::from_rgba_unmultiplied(
-        [pixmap.width() as usize, pixmap.height() as usize],
-        &pixmap.take(),
-    ))
-}
 
 #[derive(Default, Debug)]
 struct ScrollableCache {
@@ -1238,7 +1200,7 @@ fn width_body_space(ui: &Ui) -> f32 {
 }
 
 fn parse_image(ctx: &egui::Context, url: &str, data: &[u8]) -> Option<TextureHandle> {
-    let image = load_image(data).ok().or_else(|| try_render_svg(data));
+    let image = image_loading::load_image(data);
     image.map(|image| ctx.load_texture(url, image, egui::TextureOptions::LINEAR))
 }
 


### PR DESCRIPTION
Hi, and thanks for your work on `egui_commonmark`!

In this PR I've added support for showing image loading errors to the user:

![image](https://github.com/lampsitter/egui_commonmark/assets/1148717/25573693-3452-4b45-b3f8-4eea0c7ce3cf)

To implement this I added a dependency on the [`poll-promise` crate](https://github.com/EmbarkStudios/poll-promise). An added benefit is that we can also show a loading spinner while an image is being downloaded:

![image](https://github.com/lampsitter/egui_commonmark/assets/1148717/af309725-4094-49bc-9b84-58e97d377857)

I also changed the `Mutex` to the one from `parking_lot`. `egui` already depends on `parking_lot`, so it is no added dependency, and it is much more ergonomic (no need for `.unwrap()` everywhere).

I split the code in a few files - hope that's ok.