### PR TITLE
Pass image URI:s unmolested to egui

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -19,7 +19,7 @@ A *bunch* ~~of~~ __different__ `text` styles.
 
 | __A table!__ |
 | -------- |
-| ![Rust logo](examples/rust-logo-128x128.png) |
+| ![Rust logo](file://examples/rust-logo-128x128.png) |
 | Some filler text |
 | [Link to repo](https://github.com/lampsitter/egui_commonmark) |
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -19,7 +19,7 @@ A *bunch* ~~of~~ __different__ `text` styles.
 
 | __A table!__ |
 | -------- |
-| ![Rust logo](file://examples/rust-logo-128x128.png) |
+| ![Rust logo](examples/rust-logo-128x128.png) |
 | Some filler text |
 | [Link to repo](https://github.com/lampsitter/egui_commonmark) |
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,7 +384,7 @@ struct Link {
 }
 
 struct Image {
-    url: String,
+    uri: String,
     alt_text: Vec<RichText>,
 }
 
@@ -798,13 +798,8 @@ impl CommonMarkViewerInternal {
                     text: String::new(),
                 });
             }
-            pulldown_cmark::Tag::Image(_, url, _) => {
-                let url = if url.starts_with("http://") || url.starts_with("https://") {
-                    url.to_string()
-                } else {
-                    format!("file://{url}")
-                };
-                self.start_image(url);
+            pulldown_cmark::Tag::Image(_, uri, _) => {
+                self.start_image(uri.to_string());
             }
         }
     }
@@ -902,9 +897,9 @@ impl CommonMarkViewerInternal {
         }
     }
 
-    fn start_image(&mut self, url: String) {
+    fn start_image(&mut self, uri: String) {
         self.image = Some(Image {
-            url,
+            uri,
             alt_text: Vec::new(),
         });
     }
@@ -912,7 +907,7 @@ impl CommonMarkViewerInternal {
     fn end_image(&mut self, ui: &mut Ui, options: &CommonMarkOptions) {
         if let Some(image) = self.image.take() {
             let response = ui.add(
-                egui::Image::from_uri(&image.url)
+                egui::Image::from_uri(&image.uri)
                     .fit_to_original_size(1.0)
                     .max_width(self.max_width(options, ui)),
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -799,7 +799,14 @@ impl CommonMarkViewerInternal {
                 });
             }
             pulldown_cmark::Tag::Image(_, uri, _) => {
-                self.start_image(uri.to_string());
+                let has_scheme = uri.contains("://");
+                let uri = if has_scheme {
+                    uri.to_string()
+                } else {
+                    // Assume file scheme
+                    format!("file://{uri}")
+                };
+                self.start_image(uri);
             }
         }
     }


### PR DESCRIPTION
We shouldn't be adding `file://` prefixes to users URI:s for them.

If a user does this:

``` rs
egui_ctx.include_bytes("bytes://image.png", include_bytes!("image.png"));
```

they should be able to put `![](bytes://image.png)` in their markdown and have it work imho.

Of course, this change means users need to explicitly say `file://` to indicate that the image should be loaded from a file at runtime. In this case, I think explicit is better than implicit though.