### PR TITLE
Use `[patch.crates-io]` for egui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ documentation = "https://docs.rs/egui_commonmark"
 include = ["src/*.rs", "LICENSE-MIT", "LICENSE-APACHE", "Cargo.toml"]
 
 [dependencies]
-egui = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
+egui.version = "0.22"
 pulldown-cmark = { version = "0.9.3", default-features = false }
-egui_extras = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
+egui_extras.version = "0.22"
 
 syntect = { version = "5.0.0", optional = true, default-features = false, features = [
     "default-fancy",
@@ -39,9 +39,16 @@ svg = ["egui_extras/svg"]
 fetch = ["egui_extras/http"]
 
 [dev-dependencies]
-eframe = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
+eframe.version = "0.22"
 image = { version = "0.24", default-features = false, features = ["png"] }
 
 [package.metadata.docs.rs]
 # docs.rs build can fail with the fetch feature enabled
 features = ["better_syntax_highlighting", "document-features"]
+
+
+[patch.crates-io]
+# Pathed until the next egui release:
+eframe = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
+egui = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
+egui_extras = { git = "https://github.com/emilk/egui", rev = "d949eaf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,6 @@ features = ["better_syntax_highlighting", "document-features"]
 
 [patch.crates-io]
 # Pathed until the next egui release:
-eframe = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
-egui = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
-egui_extras = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
+eframe = { git = "https://github.com/emilk/egui", rev = "fdd493d48fd23047480ac5a0219fc5f206eb0dd3" }
+egui = { git = "https://github.com/emilk/egui", rev = "fdd493d48fd23047480ac5a0219fc5f206eb0dd3" }
+egui_extras = { git = "https://github.com/emilk/egui", rev = "fdd493d48fd23047480ac5a0219fc5f206eb0dd3" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ impl CommonMarkCache {
             // cache free from egui's Ui and Context types as this allows it to be created before
             // any egui instances. It also keeps the API similar to before the introduction of the
             // image loaders.
-            egui_extras::loaders::install_image_loaders(ctx);
+            egui_extras::install_image_loaders(ctx);
             self.has_installed_loaders = true;
         }
 


### PR DESCRIPTION
The advantage of using `[patch.crates-io]` is that other repositories (e.g. https://github.com/rerun-io/rerun) can update egui to any source-compatible version of `egui` without having to wait for `egui_commonmark` to also update to the exact same revision