### PR TITLE
Fix header sizing issue

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -35,6 +35,15 @@ vec.push(5);
     1. Sub item
 
 [^1]: A footnote
+
+# Header 1
+## Header 2
+### Header 3
+#### Header 4
+##### Header 5
+###### Header 6
+
+Some text.
             "#;
 
         egui::CentralPanel::default().show(ctx, |ui| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -653,8 +653,16 @@ impl CommonMarkViewerInternal {
         let mut text = RichText::new(text);
 
         if let Some(level) = self.text_style.heading {
-            let max_height = ui.text_style_height(&TextStyle::Heading);
-            let min_height = ui.text_style_height(&TextStyle::Body);
+            let max_height = ui
+                .style()
+                .text_styles
+                .get(&egui::TextStyle::Heading)
+                .map_or(32.0, |d| d.size);
+            let min_height = ui
+                .style()
+                .text_styles
+                .get(&egui::TextStyle::Body)
+                .map_or(14.0, |d| d.size);
             let diff = max_height - min_height;
             match level {
                 HeadingLevel::H1 => {


### PR DESCRIPTION
The issue originates from mixing row heights (as returned by `ui.text_style_height()`) and font sizes, which appear to be slightly different things. This PR fixes this discrepancy, leading to correct (relative) header sizing.

* Fixes rerun-io/rerun#3612