### PR TITLE
Fix building with 1.72

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.72.0"
+components = ["rustfmt", "clippy"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ const DEFAULT_THEME_LIGHT: &str = "base16-ocean.light";
 const DEFAULT_THEME_DARK: &str = "base16-ocean.dark";
 
 #[derive(Debug)]
-struct CommonMarkOptions {
+pub struct CommonMarkOptions {
     indentation_spaces: usize,
     max_image_width: Option<usize>,
     show_alt_text_on_hover: bool,


### PR DESCRIPTION
The reported MSRV of this project is 1.72, but rustc 1.72 fails to compile it:

```
error[E0446]: private type `CommonMarkOptions` in public interface
   --> src/parsers/pulldown.rs:57:5
    |
57  | /     pub fn show(
58  | |         &mut self,
59  | |         ui: &mut egui::Ui,
60  | |         cache: &mut CommonMarkCache,
...   |
63  | |         populate_split_points: bool,
64  | |     ) {
    | |_____^ can't leak private type
    |
   ::: src/lib.rs:240:1
    |
240 |   struct CommonMarkOptions {
    |   ------------------------ `CommonMarkOptions` declared as private
```

This PR fixes the compilation error, and enforces testing with `1.72` using a `rust-toolchain` file, which the CI will heed, as will any local `cargo check`.

This should probably have a patch release.