### PR TITLE
returning InnerResponse on show functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,11 +395,16 @@ impl CommonMarkViewer {
     }
 
     /// Shows rendered markdown
-    pub fn show(self, ui: &mut egui::Ui, cache: &mut CommonMarkCache, text: &str) {
+    pub fn show(
+        self,
+        ui: &mut egui::Ui,
+        cache: &mut CommonMarkCache,
+        text: &str,
+    ) -> egui::InnerResponse<()> {
         cache.prepare_show(ui.ctx());
 
         #[cfg(feature = "pulldown_cmark")]
-        parsers::pulldown::CommonMarkViewerInternal::new(self.source_id).show(
+        let response = parsers::pulldown::CommonMarkViewerInternal::new(self.source_id).show(
             ui,
             cache,
             &self.options,
@@ -408,12 +413,14 @@ impl CommonMarkViewer {
         );
 
         #[cfg(feature = "comrak")]
-        parsers::comrak::CommonMarkViewerInternal::new(self.source_id).show(
+        let response = parsers::comrak::CommonMarkViewerInternal::new(self.source_id).show(
             ui,
             cache,
             &self.options,
             text,
         );
+
+        response
     }
 
     /// Shows markdown inside a [`ScrollArea`].

--- a/src/parsers/comrak.rs
+++ b/src/parsers/comrak.rs
@@ -40,7 +40,7 @@ impl CommonMarkViewerInternal {
         cache: &mut CommonMarkCache,
         options: &CommonMarkOptions,
         text: &str,
-    ) {
+    ) -> egui::InnerResponse<()> {
         let max_width = options.max_width(ui);
         let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
 
@@ -59,7 +59,7 @@ impl CommonMarkViewerInternal {
             let root = parse_document(&arena, text, &parse_opt);
 
             self.render(ui, cache, options, max_width, root);
-        });
+        })
     }
 
     // FIXME: recursion limit...

--- a/src/parsers/pulldown.rs
+++ b/src/parsers/pulldown.rs
@@ -204,7 +204,7 @@ impl CommonMarkViewerInternal {
         options: &CommonMarkOptions,
         text: &str,
         populate_split_points: bool,
-    ) {
+    ) -> egui::InnerResponse<()> {
         let max_width = options.max_width(ui);
         let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
 
@@ -240,7 +240,7 @@ impl CommonMarkViewerInternal {
             }
 
             cache.scroll(&self.source_id).page_size = Some(ui.next_widget_position().to_vec2());
-        });
+        })
     }
 
     pub(crate) fn show_scrollable(


### PR DESCRIPTION
I thought this'd be useful for cases when user wants to listen to senses. This does not break any of existing code, and is implemented for both backends. Very small adjustment.