### PR TITLE
Implement markdown mutating checkboxes through `CommonMarkViewer::show_mut`

### DIFF
--- a/examples/show_mut.rs
+++ b/examples/show_mut.rs
@@ -67,6 +67,6 @@ const EXAMPLE_TEXT: &str = "
 # Todo list
 - [x] Exist
 - [ ] Visit [`egui_commonmark` repo](https://github.com/lampsitter/egui_commonmark)
-- [ ] Notice how the text changes in response to clicking the checkmarks.
-    - [ ] Make up your own list items
+- [ ] Notice how the top markdown text changes in response to clicking the checkmarks.
+    - [ ] Make up your own list items, by using the editor on the top.
 ";

--- a/examples/show_mut.rs
+++ b/examples/show_mut.rs
@@ -1,0 +1,72 @@
+//! Add `light` or `dark` to the end of the command to specify theme. Default
+//! is light. `cargo r --example show_mut -- dark`
+
+use eframe::egui;
+use egui_commonmark::*;
+
+struct App {
+    cache: CommonMarkCache,
+    text_buffer: String,
+}
+
+impl eframe::App for App {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                ui.add(
+                    egui::TextEdit::multiline(&mut self.text_buffer)
+                        .code_editor()
+                        .desired_width(f32::INFINITY),
+                );
+                CommonMarkViewer::new("viewer")
+                    .max_image_width(Some(512))
+                    .show_mut(ui, &mut self.cache, &mut self.text_buffer);
+            });
+        });
+    }
+}
+
+#[cfg(feature = "comrak")]
+const BACKEND: &str = "comrak";
+#[cfg(feature = "pulldown_cmark")]
+const BACKEND: &str = "pulldown_cmark";
+
+fn main() {
+    let mut args = std::env::args();
+    args.next();
+    let use_dark_theme = if let Some(theme) = args.next() {
+        if theme == "light" {
+            false
+        } else {
+            theme == "dark"
+        }
+    } else {
+        false
+    };
+
+    eframe::run_native(
+        &format!("Markdown viewer (backend '{}')", BACKEND),
+        eframe::NativeOptions::default(),
+        Box::new(move |cc| {
+            cc.egui_ctx.set_visuals(if use_dark_theme {
+                egui::Visuals::dark()
+            } else {
+                egui::Visuals::light()
+            });
+
+            Box::new(App {
+                cache: CommonMarkCache::default(),
+                text_buffer: EXAMPLE_TEXT.into(),
+            })
+        }),
+    )
+    .unwrap();
+}
+
+const EXAMPLE_TEXT: &str = "
+# Todo list
+- [x] Exist
+- [ ] Visit [`egui_commonmark` repo](https://github.com/lampsitter/egui_commonmark)
+- [ ] Notice how the text changes in response to clicking the checkmarks.
+    - [ ] Make up your own list items
+";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,8 @@ struct CommonMarkOptions {
     use_explicit_uri_scheme: bool,
     default_implicit_uri_scheme: String,
     alerts: AlertBundle,
+    /// Whether to present a mutable ui for things like checkboxes
+    mutable: bool,
 }
 
 impl Default for CommonMarkOptions {
@@ -268,6 +270,7 @@ impl Default for CommonMarkOptions {
             use_explicit_uri_scheme: false,
             default_implicit_uri_scheme: "file://".to_owned(),
             alerts: AlertBundle::gfm(),
+            mutable: false,
         }
     }
 }
@@ -427,11 +430,12 @@ impl CommonMarkViewer {
     ///
     /// The only currently implemented mutation is allowing checkboxes to be toggled through the ui.
     pub fn show_mut(
-        self,
+        mut self,
         ui: &mut egui::Ui,
         cache: &mut CommonMarkCache,
         text: &mut String,
     ) -> egui::InnerResponse<()> {
+        self.options.mutable = true;
         cache.prepare_show(ui.ctx());
 
         #[cfg(feature = "pulldown_cmark")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,7 +407,7 @@ impl CommonMarkViewer {
         cache.prepare_show(ui.ctx());
 
         #[cfg(feature = "pulldown_cmark")]
-        let response = parsers::pulldown::CommonMarkViewerInternal::new(self.source_id).show(
+        let (response, _) = parsers::pulldown::CommonMarkViewerInternal::new(self.source_id).show(
             ui,
             cache,
             &self.options,
@@ -423,7 +423,7 @@ impl CommonMarkViewer {
             text,
         );
 
-        response.0
+        response
     }
 
     /// Shows rendered markdown, and allows the rendered ui to mutate the source text.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub struct CommonMarkCache {
     #[cfg(feature = "pulldown_cmark")]
     scroll: HashMap<Id, ScrollableCache>,
     has_installed_loaders: bool,
+    pub checkmark_clicks: Vec<(bool, std::ops::Range<usize>)>,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -85,6 +86,7 @@ impl Default for CommonMarkCache {
             #[cfg(feature = "pulldown_cmark")]
             scroll: Default::default(),
             has_installed_loaders: false,
+            checkmark_clicks: Vec::new(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,6 +429,7 @@ impl CommonMarkViewer {
     /// Shows rendered markdown, and allows the rendered ui to mutate the source text.
     ///
     /// The only currently implemented mutation is allowing checkboxes to be toggled through the ui.
+    #[cfg(feature = "pulldown_cmark")]
     pub fn show_mut(
         mut self,
         ui: &mut egui::Ui,
@@ -438,19 +439,11 @@ impl CommonMarkViewer {
         self.options.mutable = true;
         cache.prepare_show(ui.ctx());
 
-        #[cfg(feature = "pulldown_cmark")]
         let (response, checkmark_events) = parsers::pulldown::CommonMarkViewerInternal::new(
             self.source_id,
         )
         .show(ui, cache, &self.options, text, false);
 
-        #[cfg(feature = "comrak")]
-        let response = parsers::comrak::CommonMarkViewerInternal::new(self.source_id).show(
-            ui,
-            cache,
-            &self.options,
-            text,
-        );
         // Update source text for checkmarks that were clicked
         for ev in checkmark_events {
             if ev.checked {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,7 @@ impl CommonMarkViewer {
         cache.prepare_show(ui.ctx());
 
         #[cfg(feature = "pulldown_cmark")]
-        let (response, checkmark_ev) = parsers::pulldown::CommonMarkViewerInternal::new(
+        let (response, checkmark_events) = parsers::pulldown::CommonMarkViewerInternal::new(
             self.source_id,
         )
         .show(ui, cache, &self.options, text, false);
@@ -451,8 +451,8 @@ impl CommonMarkViewer {
             &self.options,
             text,
         );
-
-        for ev in checkmark_ev {
+        // Update source text for checkmarks that were clicked
+        for ev in checkmark_events {
             if ev.checked {
                 text.replace_range(ev.span, "[x]")
             } else {

--- a/src/parsers/pulldown.rs
+++ b/src/parsers/pulldown.rs
@@ -341,7 +341,7 @@ impl CommonMarkViewerInternal {
             scroll_cache.split_points.clear();
         }
     }
-
+    #[allow(clippy::too_many_arguments)]
     fn process_event<'e>(
         &mut self,
         ui: &mut Ui,

--- a/src/parsers/pulldown.rs
+++ b/src/parsers/pulldown.rs
@@ -180,10 +180,10 @@ pub struct CommonMarkViewerInternal {
     fenced_code_block: Option<crate::FencedCodeBlock>,
     is_table: bool,
     is_blockquote: bool,
-    checkmark_spans: Vec<CheckmarkClickEvent>,
+    checkbox_events: Vec<CheckboxClickEvent>,
 }
 
-pub(crate) struct CheckmarkClickEvent {
+pub(crate) struct CheckboxClickEvent {
     pub(crate) checked: bool,
     pub(crate) span: Range<usize>,
 }
@@ -201,7 +201,7 @@ impl CommonMarkViewerInternal {
             fenced_code_block: None,
             is_table: false,
             is_blockquote: false,
-            checkmark_spans: Vec::new(),
+            checkbox_events: Vec::new(),
         }
     }
 }
@@ -215,7 +215,7 @@ impl CommonMarkViewerInternal {
         options: &CommonMarkOptions,
         text: &str,
         populate_split_points: bool,
-    ) -> (egui::InnerResponse<()>, Vec<CheckmarkClickEvent>) {
+    ) -> (egui::InnerResponse<()>, Vec<CheckboxClickEvent>) {
         let max_width = options.max_width(ui);
         let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
 
@@ -254,7 +254,7 @@ impl CommonMarkViewerInternal {
 
             cache.scroll(&self.source_id).page_size = Some(ui.next_widget_position().to_vec2());
         });
-        (re, std::mem::take(&mut self.checkmark_spans))
+        (re, std::mem::take(&mut self.checkbox_events))
     }
 
     pub(crate) fn show_scrollable(
@@ -499,7 +499,7 @@ impl CommonMarkViewerInternal {
                         .add(egui::Checkbox::without_text(&mut checkbox))
                         .clicked()
                     {
-                        self.checkmark_spans.push(CheckmarkClickEvent {
+                        self.checkbox_events.push(CheckboxClickEvent {
                             checked: checkbox,
                             span: src_span,
                         });

--- a/src/parsers/pulldown.rs
+++ b/src/parsers/pulldown.rs
@@ -494,14 +494,18 @@ impl CommonMarkViewerInternal {
                 newline(ui);
             }
             pulldown_cmark::Event::TaskListMarker(mut checkbox) => {
-                if ui
-                    .add(egui::Checkbox::without_text(&mut checkbox))
-                    .clicked()
-                {
-                    self.checkmark_spans.push(CheckmarkClickEvent {
-                        checked: checkbox,
-                        span: src_span,
-                    });
+                if options.mutable {
+                    if ui
+                        .add(egui::Checkbox::without_text(&mut checkbox))
+                        .clicked()
+                    {
+                        self.checkmark_spans.push(CheckmarkClickEvent {
+                            checked: checkbox,
+                            span: src_span,
+                        });
+                    }
+                } else {
+                    ui.add(Checkbox::without_text(&mut checkbox));
                 }
             }
         }


### PR DESCRIPTION
Closes #38 

This pull request neglects to implement the feature for the comrak backend. I haven't tested what happens when trying to use `show_mut` with the comrak backend.
Since the [comrak backend's future is unclear](https://github.com/lampsitter/egui_commonmark/issues/38#issuecomment-2022989555), this is acceptable.