### PR TITLE
Replace the copy icon with a checkmark after the text is copied from a codeblock

### DIFF
--- a/src/elements.rs
+++ b/src/elements.rs
@@ -118,24 +118,26 @@ pub fn code_block<'t>(
 
     // Check if we should show ✔ instead of 🗐 if the text was copied and the mouse is hovered
     let persistent_id = ui.make_persistent_id(output.response.id);
-    let mut copied_icon = ui.memory_mut(|m| *m.data.get_temp_mut_or_default::<bool>(persistent_id));
+    let copied_icon = ui.memory_mut(|m| *m.data.get_temp_mut_or_default::<bool>(persistent_id));
 
-    let copy_button = ui
-        .put(
-            egui::Rect {
-                min: position,
-                max: position,
-            },
-            egui::Button::new(if copied_icon { "✔" } else { "🗐" })
-                .small()
-                .frame(false)
-                .fill(egui::Color32::TRANSPARENT),
-        )
-        .on_hover_cursor(egui::CursorIcon::PointingHand);
+    let copy_button = ui.put(
+        egui::Rect {
+            min: position,
+            max: position,
+        },
+        egui::Button::new(if copied_icon { "✔" } else { "🗐" })
+            .small()
+            .frame(false)
+            .fill(egui::Color32::TRANSPARENT),
+    );
 
-    // Update `copied_icon` and write it back to the persistent storage
-    copied_icon = (copied_icon || copy_button.clicked()) && copy_button.hovered();
-    ui.memory_mut(|m| *m.data.get_temp_mut_or_default(persistent_id) = copied_icon);
+    // Update icon state in persistent memory
+    if copied_icon && !copy_button.hovered() {
+        ui.memory_mut(|m| *m.data.get_temp_mut_or_default(persistent_id) = false);
+    }
+    if !copied_icon && copy_button.clicked() {
+        ui.memory_mut(|m| *m.data.get_temp_mut_or_default(persistent_id) = true);
+    }
 
     if copy_button.clicked() {
         use egui::TextBuffer as _;

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -116,16 +116,26 @@ pub fn code_block<'t>(
         frame_rect.right_top().y + spacing.button_padding.y * 2.0,
     );
 
-    let copy_button = ui.put(
-        egui::Rect {
-            min: position,
-            max: position,
-        },
-        egui::Button::new("🗐")
-            .small()
-            .frame(false)
-            .fill(egui::Color32::TRANSPARENT),
-    );
+    // Check if we should show ✔ instead of 🗐 if the text was copied and the mouse is hovered
+    let persistent_id = ui.make_persistent_id(output.response.id);
+    let mut copied_icon = ui.memory_mut(|m| *m.data.get_temp_mut_or_default::<bool>(persistent_id));
+
+    let copy_button = ui
+        .put(
+            egui::Rect {
+                min: position,
+                max: position,
+            },
+            egui::Button::new(if copied_icon { "✔" } else { "🗐" })
+                .small()
+                .frame(false)
+                .fill(egui::Color32::TRANSPARENT),
+        )
+        .on_hover_cursor(egui::CursorIcon::PointingHand);
+
+    // Update `copied_icon` and write it back to the persistent storage
+    copied_icon = (copied_icon || copy_button.clicked()) && copy_button.hovered();
+    ui.memory_mut(|m| *m.data.get_temp_mut_or_default(persistent_id) = copied_icon);
 
     if copy_button.clicked() {
         use egui::TextBuffer as _;


### PR DESCRIPTION
small ux improvement:

* Replace the copy icon with a checkmark after the text is copied from a codeblock
* Change the cursor to a PointingHand when hoving over the copy icon

https://github.com/lampsitter/egui_commonmark/assets/108888572/61e0899f-7740-4c3f-adda-2e4ce1aa18a4

