### PR TITLE
Better text wrapping in lists (fix #39)

### DIFF
--- a/src/elements.rs
+++ b/src/elements.rs
@@ -41,7 +41,7 @@ pub(crate) fn number_point(ui: &mut Ui, number: &str) {
     ui.painter().text(
         rect.right_center(),
         egui::Align2::RIGHT_CENTER,
-        format!("{number}. "),
+        format!("{number}."),
         TextStyle::Body.resolve(ui.style()),
         ui.visuals().strong_text_color(),
     );
@@ -240,14 +240,19 @@ impl List {
             newline(ui);
             ui.label(" ".repeat((len - 1) * options.indentation_spaces));
 
-            if let Some(number) = &mut item.current_number {
-                number_point(ui, &number.to_string());
-                *number += 1;
-            } else if len > 1 {
-                bullet_point_hollow(ui);
-            } else {
-                bullet_point(ui);
-            }
+            ui.horizontal(|ui| {
+                if let Some(number) = &mut item.current_number {
+                    number_point(ui, &number.to_string());
+                    *number += 1;
+                } else if len > 1 {
+                    bullet_point_hollow(ui);
+                } else {
+                    bullet_point(ui);
+                }
+
+                // Add some space between the bullet point and the text that follows it
+                ui.add_space(4.0);
+            });
         } else {
             unreachable!();
         }

--- a/src/parsers/pulldown.rs
+++ b/src/parsers/pulldown.rs
@@ -512,16 +512,21 @@ impl CommonMarkViewerInternal {
     }
 
     fn event_text(&mut self, text: CowStr, ui: &mut Ui) {
-        let rich_text = self.text_style.to_richtext(ui, &text);
-        if let Some(image) = &mut self.image {
-            image.alt_text.push(rich_text);
-        } else if let Some(block) = &mut self.fenced_code_block {
-            block.content.push_str(&text);
-        } else if let Some(link) = &mut self.link {
-            link.text.push(rich_text);
-        } else {
-            ui.label(rich_text);
-        }
+        // Use horizontal layout so when it wraps inside lists the next line
+        // starts after the bullet point (https://github.com/lampsitter/egui_commonmark/issues/39)
+        ui.horizontal(|ui| {
+            let rich_text = self.text_style.to_richtext(ui, &text);
+            if let Some(image) = &mut self.image {
+                image.alt_text.push(rich_text);
+            } else if let Some(block) = &mut self.fenced_code_block {
+                block.content.push_str(&text);
+            } else if let Some(link) = &mut self.link {
+                link.text.push(rich_text);
+            } else {
+                // Text does not wrap by default in horizontal layout
+                ui.add(egui::Label::new(rich_text).wrap(true));
+            }
+        });
     }
 
     fn start_tag(&mut self, ui: &mut Ui, tag: pulldown_cmark::Tag, options: &CommonMarkOptions) {


### PR DESCRIPTION
Makes wrapped text in lists start after the bulletpoint or element number (fixes #39)

## Comparison:

- Before:
  ![image](https://github.com/lampsitter/egui_commonmark/assets/108888572/3242a987-92b7-4b03-9653-0a951d19fc6e)

- After:
  ![image](https://github.com/lampsitter/egui_commonmark/assets/108888572/2640b286-809b-466f-a389-ef158c98d7f6)

> [!NOTE]
> This commit also adds 4 pixels of space between the bulletpoint and the content that follows it. In my opinion it looks much better than what we had previously, but I can remove it if you find it wrong :^)

