### PR TITLE
Experimental LaTeX parser and renderer in book example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ comrak = { version = "0.20.0", default-features = false, optional = true }
 pulldown-cmark = { git = "https://github.com/pulldown-cmark/pulldown-cmark.git", branch = "branch_0.11", default-features = false, optional = true }
 
 [features]
-default = ["load-images", "pulldown_cmark"]
+default = ["load-images", "pulldown_cmark", "math"]
 
 pulldown_cmark = ["dep:pulldown-cmark"]
 comrak = ["dep:comrak"]
@@ -44,9 +44,14 @@ svg = ["egui_extras/svg"]
 ## Images with urls will be downloaded and displayed
 fetch = ["egui_extras/http"]
 
+## Enable pulldown_cmark's math parser
+math = []
+
 [dev-dependencies]
 eframe = { version = "0.27", default-features = false, features = ["default_fonts", "glow"] }
-image = { version = "0.24", default-features = false, features = ["png"] }
+image = { version = "0.25", default-features = false, features = ["png"] }
+egui_extras = { version = "0.27", features = ["svg"] } # required for math rendering
+mathjax_svg = "3.1" # required for LaTeX -> SVG
 
 [package.metadata.docs.rs]
 features = ["better_syntax_highlighting", "document-features"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ syntect = { version = "5.0.0", optional = true, default-features = false, featur
 document-features = { version = "0.2", optional = true }
 
 comrak = { version = "0.20.0", default-features = false, optional = true }
-pulldown-cmark = { version = "0.10", default-features = false, optional = true }
+pulldown-cmark = { git = "https://github.com/pulldown-cmark/pulldown-cmark.git", branch = "branch_0.11", default-features = false, optional = true }
 
 [features]
 default = ["load-images", "pulldown_cmark"]

--- a/examples/book.rs
+++ b/examples/book.rs
@@ -121,12 +121,16 @@ fn main() {
                         content: include_str!("markdown/code-blocks.md").to_owned(),
                     },
                     Page {
-                        name: "Block Quotes ".to_owned(),
+                        name: "Block Quotes".to_owned(),
                         content: include_str!("markdown/blockquotes.md").to_owned(),
                     },
                     Page {
-                        name: "Tables ".to_owned(),
+                        name: "Tables".to_owned(),
                         content: include_str!("markdown/tables.md").to_owned(),
+                    },
+                    Page {
+                        name: "Math".to_owned(),
+                        content: include_str!("markdown/math.md").to_owned(),
                     },
                 ],
             })

--- a/examples/markdown/math.md
+++ b/examples/markdown/math.md
@@ -1,6 +1,58 @@
 When $a \ne 0$, there are two solutions to $(ax^2 + bx + c = 0)$ and they are 
 $$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
 
+- Block equations:
+  
+    $$ \frac{\partial \rho}{\partial t} + \nabla \cdot \vec{j} = 0 \,. \label{eq:continuity} $$
+
+- Stokes' theorem:
+
+$$ \begin{equation}
+    \int_{\partial\Omega} \omega = \int_{\Omega} \mathrm{d}\omega \,.
+    \label{eq:stokes}
+  \end{equation} $$
+
+- Maxwell's equations:
+
+$$
+\begin{align}
+  \nabla \cdot  \vec{E} & = \rho \nonumber                                              \\
+  \nabla \cdot  \vec{B} & = 0    \nonumber                                              \\
+  \nabla \times \vec{E} & = - \frac{\partial \vec{B}}{\partial t} \label{eq:maxwell}    \\
+  \nabla \times \vec{B} & = \vec{j} + \frac{\partial \vec{E}}{\partial t} \nonumber \,.
+\end{align}
+$$
+
+- L'Hôpital's rule
+  
+$$
+\begin{align}
+  \lim_{x\to 0}{\frac{e^x-1}{2x}}
+  \overset{\left[\frac{0}{0}\right]}{\underset{\mathrm{H}}{=}}
+  \lim_{x\to 0}{\frac{e^x}{2}}={\frac{1}{2}}
+\end{align}
+$$
+
+- More stuff
+
+$$
+\begin{align}
+  z = \overbrace{
+  \underbrace{x}_\text{real} + i
+  \underbrace{y}_\text{imaginary}
+  }^\text{complex number}
+\end{align}
+$$
+
+- Multiline subscripts: $$
+\begin{align}
+  \prod_{\substack{
+  1\le i \le n      \\
+  1\le j \le m}}
+  M_{i,j}
+\end{align}
+$$
+
 ---
 
 ## Edge cases

--- a/examples/markdown/math.md
+++ b/examples/markdown/math.md
@@ -1,0 +1,8 @@
+When $a \ne 0$, there are two solutions to $(ax^2 + bx + c = 0)$ and they are 
+$$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
+
+---
+
+## Edge cases
+
+Cheese is $10.40 + $0.20 tax

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,7 +431,6 @@ impl<'a> CommonMarkViewer<'a> {
             cache,
             &self.options,
             text,
-            self.math_fn,
         );
 
         response

--- a/src/parsers/pulldown.rs
+++ b/src/parsers/pulldown.rs
@@ -564,6 +564,7 @@ impl CommonMarkViewerInternal {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn event(
         &mut self,
         ui: &mut Ui,

--- a/src/parsers/pulldown.rs
+++ b/src/parsers/pulldown.rs
@@ -162,11 +162,13 @@ fn parse_alerts<'a>(
 }
 
 /// Supported pulldown_cmark options
+#[inline]
 fn parser_options() -> Options {
     Options::ENABLE_TABLES
         | Options::ENABLE_TASKLISTS
         | Options::ENABLE_STRIKETHROUGH
         | Options::ENABLE_FOOTNOTES
+        | Options::ENABLE_MATH
 }
 
 pub struct CommonMarkViewerInternal {
@@ -507,6 +509,12 @@ impl CommonMarkViewerInternal {
                 } else {
                     ui.add(ImmutableCheckbox::without_text(&mut checkbox));
                 }
+            }
+            pulldown_cmark::Event::InlineMath(tex) => {
+                println!("Math: {tex}");
+            }
+            pulldown_cmark::Event::DisplayMath(tex) => {
+                println!("Math: {tex}");
             }
         }
     }

--- a/src/parsers/pulldown.rs
+++ b/src/parsers/pulldown.rs
@@ -186,11 +186,13 @@ fn parse_alerts<'a>(
 }
 
 /// Supported pulldown_cmark options
+#[inline]
 fn parser_options() -> Options {
     Options::ENABLE_TABLES
         | Options::ENABLE_TASKLISTS
         | Options::ENABLE_STRIKETHROUGH
         | Options::ENABLE_FOOTNOTES
+        | Options::ENABLE_MATH
 }
 
 pub struct CommonMarkViewerInternal {
@@ -574,6 +576,12 @@ impl CommonMarkViewerInternal {
                 } else {
                     ui.add(ImmutableCheckbox::without_text(&mut checkbox));
                 }
+            }
+            pulldown_cmark::Event::InlineMath(tex) => {
+                println!("Math: {tex}");
+            }
+            pulldown_cmark::Event::DisplayMath(tex) => {
+                println!("Math: {tex}");
             }
         }
     }

--- a/src/parsers/pulldown.rs
+++ b/src/parsers/pulldown.rs
@@ -495,6 +495,7 @@ impl CommonMarkViewerInternal {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn event(
         &mut self,
         ui: &mut Ui,

--- a/src/parsers/pulldown.rs
+++ b/src/parsers/pulldown.rs
@@ -2,7 +2,7 @@
 
 use std::ops::Range;
 
-use crate::{elements::*, Alert, AlertBundle};
+use crate::{elements::*, Alert, AlertBundle, RenderMathFn};
 use crate::{CommonMarkCache, CommonMarkOptions};
 
 use egui::{self, Id, Pos2, TextStyle, Ui, Vec2};
@@ -163,12 +163,23 @@ fn parse_alerts<'a>(
 
 /// Supported pulldown_cmark options
 #[inline]
+#[cfg(feature = "math")]
 fn parser_options() -> Options {
     Options::ENABLE_TABLES
         | Options::ENABLE_TASKLISTS
         | Options::ENABLE_STRIKETHROUGH
         | Options::ENABLE_FOOTNOTES
         | Options::ENABLE_MATH
+}
+
+/// Supported pulldown_cmark options
+#[inline]
+#[cfg(not(feature = "math"))]
+fn parser_options() -> Options {
+    Options::ENABLE_TABLES
+        | Options::ENABLE_TASKLISTS
+        | Options::ENABLE_STRIKETHROUGH
+        | Options::ENABLE_FOOTNOTES
 }
 
 pub struct CommonMarkViewerInternal {
@@ -217,6 +228,7 @@ impl CommonMarkViewerInternal {
         options: &CommonMarkOptions,
         text: &str,
         populate_split_points: bool,
+        math_fn: Option<&RenderMathFn>,
     ) -> (egui::InnerResponse<()>, Vec<CheckboxClickEvent>) {
         let max_width = options.max_width(ui);
         let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
@@ -235,7 +247,16 @@ impl CommonMarkViewerInternal {
                 let is_element_end = matches!(e, pulldown_cmark::Event::End(_));
                 let should_add_split_point = self.list.is_inside_a_list() && is_element_end;
 
-                self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
+                self.process_event(
+                    ui,
+                    &mut events,
+                    e,
+                    src_span,
+                    cache,
+                    options,
+                    max_width,
+                    math_fn,
+                );
 
                 if populate_split_points && should_add_split_point {
                     let scroll_cache = cache.scroll(&self.source_id);
@@ -265,6 +286,7 @@ impl CommonMarkViewerInternal {
         cache: &mut CommonMarkCache,
         options: &CommonMarkOptions,
         text: &str,
+        math_fn: Option<&RenderMathFn>,
     ) {
         let available_size = ui.available_size();
         let scroll_id = self.source_id.with("_scroll_area");
@@ -274,7 +296,7 @@ impl CommonMarkViewerInternal {
                 .id_source(scroll_id)
                 .auto_shrink([false, true])
                 .show(ui, |ui| {
-                    self.show(ui, cache, options, text, true);
+                    self.show(ui, cache, options, text, true, math_fn);
                 });
             // Prevent repopulating points twice at startup
             cache.scroll(&self.source_id).available_size = available_size;
@@ -330,7 +352,16 @@ impl CommonMarkViewerInternal {
                         .take(last_event_index - first_event_index);
 
                     while let Some((_, (e, src_span))) = events.next() {
-                        self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
+                        self.process_event(
+                            ui,
+                            &mut events,
+                            e,
+                            src_span,
+                            cache,
+                            options,
+                            max_width,
+                            math_fn,
+                        );
                     }
                 });
             });
@@ -353,11 +384,12 @@ impl CommonMarkViewerInternal {
         cache: &mut CommonMarkCache,
         options: &CommonMarkOptions,
         max_width: f32,
+        math_fn: Option<&RenderMathFn>,
     ) {
-        self.event(ui, event, src_span, cache, options, max_width);
-        self.fenced_code_block(events, max_width, cache, options, ui);
-        self.table(events, cache, options, ui, max_width);
-        self.blockquote(events, max_width, cache, options, ui);
+        self.event(ui, event, src_span, cache, options, max_width, math_fn);
+        self.fenced_code_block(events, max_width, cache, options, ui, math_fn);
+        self.table(events, cache, options, ui, max_width, math_fn);
+        self.blockquote(events, max_width, cache, options, ui, math_fn);
     }
 
     fn blockquote<'e>(
@@ -367,6 +399,7 @@ impl CommonMarkViewerInternal {
         cache: &mut CommonMarkCache,
         options: &CommonMarkOptions,
         ui: &mut Ui,
+        math_fn: Option<&RenderMathFn>,
     ) {
         if self.is_blockquote {
             let mut collected_events = delayed_events(events, pulldown_cmark::TagEnd::BlockQuote);
@@ -374,14 +407,14 @@ impl CommonMarkViewerInternal {
             if let Some(alert) = parse_alerts(&options.alerts, &mut collected_events) {
                 alert.ui(ui, |ui| {
                     for (event, src_span) in collected_events.into_iter() {
-                        self.event(ui, event, src_span, cache, options, max_width);
+                        self.event(ui, event, src_span, cache, options, max_width, math_fn);
                     }
                 })
             } else {
                 blockquote(ui, ui.visuals().weak_text_color(), |ui| {
                     self.text_style.quote = true;
                     for (event, src_span) in collected_events {
-                        self.event(ui, event, src_span, cache, options, max_width);
+                        self.event(ui, event, src_span, cache, options, max_width, math_fn);
                     }
                     self.text_style.quote = false;
                 });
@@ -400,10 +433,11 @@ impl CommonMarkViewerInternal {
         cache: &mut CommonMarkCache,
         options: &CommonMarkOptions,
         ui: &mut Ui,
+        math_fn: Option<&RenderMathFn>,
     ) {
         while self.fenced_code_block.is_some() {
             if let Some((_, (e, src_span))) = events.next() {
-                self.event(ui, e, src_span, cache, options, max_width);
+                self.event(ui, e, src_span, cache, options, max_width, math_fn);
             } else {
                 break;
             }
@@ -417,6 +451,7 @@ impl CommonMarkViewerInternal {
         options: &CommonMarkOptions,
         ui: &mut Ui,
         max_width: f32,
+        math_fn: Option<&RenderMathFn>,
     ) {
         if self.is_table {
             newline(ui);
@@ -432,7 +467,7 @@ impl CommonMarkViewerInternal {
                         ui.horizontal(|ui| {
                             for (e, src_span) in col {
                                 self.should_insert_newline = false;
-                                self.event(ui, e, src_span, cache, options, max_width);
+                                self.event(ui, e, src_span, cache, options, max_width, math_fn);
                             }
                         });
                     }
@@ -444,7 +479,7 @@ impl CommonMarkViewerInternal {
                             ui.horizontal(|ui| {
                                 for (e, src_span) in col {
                                     self.should_insert_newline = false;
-                                    self.event(ui, e, src_span, cache, options, max_width);
+                                    self.event(ui, e, src_span, cache, options, max_width, math_fn);
                                 }
                             });
                         }
@@ -468,6 +503,7 @@ impl CommonMarkViewerInternal {
         cache: &mut CommonMarkCache,
         options: &CommonMarkOptions,
         max_width: f32,
+        math_fn: Option<&RenderMathFn>,
     ) {
         match event {
             pulldown_cmark::Event::Start(tag) => self.start_tag(ui, tag, options),
@@ -511,10 +547,14 @@ impl CommonMarkViewerInternal {
                 }
             }
             pulldown_cmark::Event::InlineMath(tex) => {
-                println!("Math: {tex}");
+                if let Some(math_fn) = math_fn {
+                    math_fn(ui, &tex, true);
+                }
             }
             pulldown_cmark::Event::DisplayMath(tex) => {
-                println!("Math: {tex}");
+                if let Some(math_fn) = math_fn {
+                    math_fn(ui, &tex, false);
+                }
             }
         }
     }


### PR DESCRIPTION
![image](https://github.com/lampsitter/egui_commonmark/assets/108888572/c509de6a-cba6-4fea-b8b2-2506a556743d)

This is implemented using the new `pulldown_cmark` 0.11 version which supports simple math parsing (which is still not published, so for now we pull it from Git)

The renderer calls out to [MathJax](https://www.mathjax.org/) with [mathjax_svg](https://github.com/gw31415/mathjax_svg) (which embeds the V8 engine into the executable :trollface: and uses MathJax to convert LaTeX into an svg). This is then rendered as an egui image using `egui_extra`'s `svg` feature (which uses Resvg).

This doesn't really have to be LaTeX, since the entirety of rendering math expressions is handled by the user, not egui_commonmark. Never really tried to mess with Typst, but it could be entirely possible to implement it.

TODO: proper error handling, `math` feature, center text horizontally with math equations, select and copy equations, implement Typst rendering

closes https://github.com/lampsitter/egui_commonmark/issues/25