### PR TITLE
Twemoji

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ document-features = { version = "0.2", optional = true }
 
 comrak = { version = "0.20.0", default-features = false, optional = true }
 pulldown-cmark = { version = "0.10", default-features = false, optional = true }
-egui-twemoji = "0.2.0"
+egui-twemoji = "0.3.0"
 
 [features]
 default = ["load-images", "pulldown_cmark"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ document-features = { version = "0.2", optional = true }
 
 comrak = { version = "0.20.0", default-features = false, optional = true }
 pulldown-cmark = { version = "0.10", default-features = false, optional = true }
+egui-twemoji = "0.2.0"
 
 [features]
 default = ["load-images", "pulldown_cmark"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ document-features = { version = "0.2", optional = true }
 
 comrak = { version = "0.22.0", default-features = false, optional = true }
 pulldown-cmark = { version = "0.10", default-features = false, optional = true }
-egui-twemoji = "0.3.0"
+egui-twemoji = { version = "0.3.0", optional = true }
 
 [features]
 default = ["load-images", "pulldown_cmark"]
@@ -44,6 +44,9 @@ svg = ["egui_extras/svg"]
 
 ## Images with urls will be downloaded and displayed
 fetch = ["egui_extras/http"]
+
+## Enable twemoji support
+twemoji = ["egui-twemoji"]
 
 [dev-dependencies]
 eframe = { version = "0.27", default-features = false, features = ["default_fonts", "glow"] }

--- a/examples/markdown/hello_world.md
+++ b/examples/markdown/hello_world.md
@@ -33,4 +33,4 @@ vec.push(5);
 ##### Header 5
 ###### Header 6
 
-Some text.
+Some text, with emojis 😸 🙀 (make sure to run with `--features svg`).

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -48,7 +48,7 @@ pub(crate) fn number_point(ui: &mut Ui, number: &str) {
 }
 
 pub(crate) fn footnote_start(ui: &mut Ui, note: &str) {
-    ui.label(RichText::new(note).raised().strong().small());
+    egui_twemoji::EmojiLabel::new(RichText::new(note).raised().strong().small()).show(ui);
 }
 
 pub(crate) fn footnote(ui: &mut Ui, text: &str) {

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -47,8 +47,17 @@ pub(crate) fn number_point(ui: &mut Ui, number: &str) {
     );
 }
 
+#[inline(always)]
+pub(crate) fn label(ui: &mut Ui, text: impl Into<RichText>) {
+    #[cfg(feature = "twemoji")]
+    egui_twemoji::EmojiLabel::new(text).show(ui);
+
+    #[cfg(not(feature = "twemoji"))]
+    ui.label(text.into());
+}
+
 pub(crate) fn footnote_start(ui: &mut Ui, note: &str) {
-    egui_twemoji::EmojiLabel::new(RichText::new(note).raised().strong().small()).show(ui);
+    label(ui, RichText::new(note).raised().strong().small());
 }
 
 pub(crate) fn footnote(ui: &mut Ui, text: &str) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ compile_error!("Cannot have multiple different parsing backends enabled at the s
 #[cfg(not(any(feature = "comrak", feature = "pulldown_cmark")))]
 compile_error!("Either the pulldown_cmark or comrak backend must be enabled");
 
+use elements::label;
 #[cfg(feature = "better_syntax_highlighting")]
 use syntect::{
     easy::HighlightLines,
@@ -624,7 +625,7 @@ impl Image {
         if !self.alt_text.is_empty() && options.show_alt_text_on_hover {
             response.on_hover_ui_at_pointer(|ui| {
                 for alt in self.alt_text {
-                    egui_twemoji::EmojiLabel::new(alt).show(ui);
+                    label(ui, alt);
                 }
             });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -624,7 +624,7 @@ impl Image {
         if !self.alt_text.is_empty() && options.show_alt_text_on_hover {
             response.on_hover_ui_at_pointer(|ui| {
                 for alt in self.alt_text {
-                    ui.label(alt);
+                    egui_twemoji::EmojiLabel::new(alt).show(ui);
                 }
             });
         }

--- a/src/parsers/comrak.rs
+++ b/src/parsers/comrak.rs
@@ -310,7 +310,7 @@ impl CommonMarkViewerInternal {
         } else if let Some(link) = &mut self.link {
             link.text.push(rich_text);
         } else {
-            egui_twemoji::EmojiLabel::new(rich_text).show(ui);
+            label(ui, rich_text);
         }
     }
 }

--- a/src/parsers/comrak.rs
+++ b/src/parsers/comrak.rs
@@ -304,7 +304,7 @@ impl CommonMarkViewerInternal {
         } else if let Some(link) = &mut self.link {
             link.text.push(rich_text);
         } else {
-            ui.label(rich_text);
+            egui_twemoji::EmojiLabel::new(rich_text).show(ui);
         }
     }
 }

--- a/src/parsers/pulldown.rs
+++ b/src/parsers/pulldown.rs
@@ -587,7 +587,7 @@ impl CommonMarkViewerInternal {
         } else if let Some(link) = &mut self.link {
             link.text.push(rich_text);
         } else {
-            egui_twemoji::EmojiLabel::new(rich_text).show(ui);
+            label(ui, rich_text);
         }
     }
 

--- a/src/parsers/pulldown.rs
+++ b/src/parsers/pulldown.rs
@@ -587,7 +587,7 @@ impl CommonMarkViewerInternal {
         } else if let Some(link) = &mut self.link {
             link.text.push(rich_text);
         } else {
-            ui.label(rich_text);
+            egui_twemoji::EmojiLabel::new(rich_text).show(ui);
         }
     }
 


### PR DESCRIPTION
Use [egui-twemoji](https://github.com/zeozeozeo/egui-twemoji) to render emojis as colored twemojis. Gated behind `twemoji` feature.

![image](https://github.com/lampsitter/egui_commonmark/assets/108888572/3b14ac97-5ba1-484b-a5e9-865b66539560)

(if this is out of the scope of this project, this can be closed)