### PR TITLE
Add option for displaying hyperlink url when hovered

### DIFF
--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -121,6 +121,12 @@ impl CommonMarkViewer {
         self
     }
 
+    /// Show destination url when hovering over links. By default this is enabled.
+    pub fn show_link_url_on_hover(mut self, show: bool) -> Self {
+        self.options.show_link_url_on_hover = show;
+        self
+    }
+
     /// Allows changing the default implicit `file://` uri scheme.
     /// This does nothing if [`explicit_image_uri_scheme`](`Self::explicit_image_uri_scheme`) is enabled
     ///

--- a/egui_commonmark/src/parsers/comrak.rs
+++ b/egui_commonmark/src/parsers/comrak.rs
@@ -267,7 +267,7 @@ impl CommonMarkViewerInternal {
                     self.render(ui, cache, options, max_width, c);
 
                     if let Some(link) = self.link.take() {
-                        link.end(ui, cache);
+                        link.end(ui, cache, options.show_link_url_on_hover);
                     }
                 }
 

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -544,7 +544,7 @@ impl CommonMarkViewerInternal {
             }
             pulldown_cmark::TagEnd::Link { .. } => {
                 if let Some(link) = self.link.take() {
-                    link.end(ui, cache);
+                    link.end(ui, cache, options.show_link_url_on_hover);
                 }
             }
             pulldown_cmark::TagEnd::Image { .. } => {

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -23,6 +23,7 @@ pub struct CommonMarkOptions {
     pub indentation_spaces: usize,
     pub max_image_width: Option<usize>,
     pub show_alt_text_on_hover: bool,
+    pub show_link_url_on_hover: bool,
     pub default_width: Option<usize>,
     #[cfg(feature = "better_syntax_highlighting")]
     pub theme_light: String,
@@ -41,6 +42,7 @@ impl Default for CommonMarkOptions {
             indentation_spaces: 4,
             max_image_width: None,
             show_alt_text_on_hover: true,
+            show_link_url_on_hover: true,
             default_width: None,
             #[cfg(feature = "better_syntax_highlighting")]
             theme_light: DEFAULT_THEME_LIGHT.to_owned(),
@@ -168,7 +170,7 @@ pub struct Link {
 }
 
 impl Link {
-    pub fn end(self, ui: &mut Ui, cache: &mut CommonMarkCache) {
+    pub fn end(self, ui: &mut Ui, cache: &mut CommonMarkCache, show_url: bool) {
         let Self { destination, text } = self;
 
         let mut layout_job = LayoutJob::default();
@@ -186,7 +188,10 @@ impl Link {
                 cache.link_hooks_mut().insert(destination, true);
             }
         } else {
-            ui.hyperlink_to(layout_job, destination);
+            let re = ui.hyperlink_to(layout_job, &destination);
+            if show_url {
+                re.on_hover_text(&destination);
+            }
         }
     }
 }

--- a/egui_commonmark_macros/src/generator.rs
+++ b/egui_commonmark_macros/src/generator.rs
@@ -618,7 +618,7 @@ impl CommonMarkViewerInternal {
                     egui_commonmark_backend::Link {
                         destination: #destination.to_owned(),
                         text: vec![#text_stream]
-                    }.end(ui, #cache);)
+                    }.end(ui, #cache, options.show_link_url_on_hover);)
                 } else {
                     TokenStream::new()
                 }


### PR DESCRIPTION
It's useful for the user to know where the link leads before they click it.

This option is on by default, because I think it's sensible to do this.