### PR TITLE
Do not include default egui features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ version = "0.17.0"
 repository = "https://github.com/lampsitter/egui_commonmark"
 
 [workspace.dependencies]
-egui_extras = "0.28"
-egui = "0.28"
+egui_extras = { version = "0.28", default-features = false }
+egui = { version = "0.28", default-features = false }
 
 egui_commonmark_backend = { version = "0.17.0", path = "egui_commonmark_backend", default-features = false }
 egui_commonmark_macros = { version = "0.17.0", path = "egui_commonmark_macros", default-features = false }


### PR DESCRIPTION
Pulling this crate will activate default features like `default_fonts`. egui_commonmark should not decide whether to include those features or not.

In my own project since I bring in my own fonts, I can turn off `default_fonts` which shaves around 1 MB from the final executable.
