### PR TITLE
Remove explicit Id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Changed
 
+- `CommonMarkViewer::new` no longer takes in an id.
+- `commonmark!` and `commonmark_str!` no longer takes in an id.
+- `CommonMarkViewer::show_scrollable` takes in an id explicity.
+
 - Updated pulldown-cmark to 0.12
 - Newlines are no longer inserted before/after markdown ([#56](https://github.com/lampsitter/egui_commonmark/pull/56))
     > For the old behaviour you can call `ui.label("");` before and and after

--- a/egui_commonmark/examples/book.rs
+++ b/egui_commonmark/examples/book.rs
@@ -50,7 +50,7 @@ impl App {
             egui::Frame::none()
                 .inner_margin(egui::Margin::symmetric(5.0, 0.0))
                 .show(ui, |ui| {
-                    CommonMarkViewer::new("viewer")
+                    CommonMarkViewer::new()
                         .default_width(Some(200))
                         .max_image_width(Some(512))
                         .show(

--- a/egui_commonmark/examples/hello_world.rs
+++ b/egui_commonmark/examples/hello_world.rs
@@ -16,7 +16,7 @@ impl eframe::App for App {
         let text = include_str!("markdown/hello_world.md");
         egui::CentralPanel::default().show(ctx, |ui| {
             egui::ScrollArea::vertical().show(ui, |ui| {
-                CommonMarkViewer::new("viewer")
+                CommonMarkViewer::new()
                     .max_image_width(Some(512))
                     .show(ui, &mut self.cache, text);
             });

--- a/egui_commonmark/examples/interactive.rs
+++ b/egui_commonmark/examples/interactive.rs
@@ -21,7 +21,7 @@ impl eframe::App for App {
                 .show_inside(ui, |ui| ui.text_edit_multiline(&mut self.markdown));
             egui::CentralPanel::default().show_inside(ui, |ui| {
                 egui::ScrollArea::vertical().show(ui, |ui| {
-                    CommonMarkViewer::new("viewer").show(ui, &mut self.cache, &self.markdown);
+                    CommonMarkViewer::new().show(ui, &mut self.cache, &self.markdown);
                 });
             });
         });

--- a/egui_commonmark/examples/link_hooks.rs
+++ b/egui_commonmark/examples/link_hooks.rs
@@ -28,7 +28,7 @@ Notice how the destination is not shown on [hover](#prev) unlike with [urls](htt
 
         egui::CentralPanel::default().show(ctx, |ui| {
             egui::ScrollArea::vertical().show(ui, |ui| {
-                CommonMarkViewer::new("viewer").show(ui, &mut self.cache, p[self.curr_page]);
+                CommonMarkViewer::new().show(ui, &mut self.cache, p[self.curr_page]);
             });
         });
     }

--- a/egui_commonmark/examples/macros.rs
+++ b/egui_commonmark/examples/macros.rs
@@ -16,71 +16,64 @@ impl eframe::App for App {
         egui::CentralPanel::default().show(ctx, |ui| {
             egui::ScrollArea::vertical().show(ui, |ui| {
                 // Embed text directly
-                commonmark!("n1", ui, &mut self.cache, "Hello, world");
+                commonmark!(ui, &mut self.cache, "Hello, world");
 
                 // In cases like these it's better to use egui::Separator directly
-                commonmark!("n1-1", ui, &mut self.cache, "------------");
+                commonmark!(ui, &mut self.cache, "------------");
 
                 // From a file like include_str! NOTE: This does not cause a recompile when the
                 // file has changed!
                 commonmark_str!(
-                    "n2",
                     ui,
                     &mut self.cache,
                     "egui_commonmark/examples/markdown/hello_world.md"
                 );
-                commonmark!("n4", ui, &mut self.cache, "------------");
+                commonmark!(ui, &mut self.cache, "------------");
 
                 commonmark_str!(
-                    "n3",
                     ui,
                     &mut self.cache,
                     "egui_commonmark/examples/markdown/headers.md"
                 );
-                commonmark!("n5", ui, &mut self.cache, "------------");
+                commonmark!(ui, &mut self.cache, "------------");
 
                 commonmark_str!(
-                    "n6",
                     ui,
                     &mut self.cache,
                     "egui_commonmark/examples/markdown/lists.md"
                 );
 
-                commonmark!("n6", ui, &mut self.cache, "------------");
+                commonmark!(ui, &mut self.cache, "------------");
 
                 commonmark_str!(
-                    "n7",
                     ui,
                     &mut self.cache,
                     "egui_commonmark/examples/markdown/code-blocks.md"
                 );
 
-                commonmark!("n4", ui, &mut self.cache, "------------");
+                commonmark!(ui, &mut self.cache, "------------");
 
                 commonmark_str!(
-                    "n9",
                     ui,
                     &mut self.cache,
                     "egui_commonmark/examples/markdown/blockquotes.md"
                 );
 
-                commonmark!("n10", ui, &mut self.cache, "------------");
+                commonmark!(ui, &mut self.cache, "------------");
 
                 commonmark_str!(
-                    "n11",
                     ui,
                     &mut self.cache,
                     "egui_commonmark/examples/markdown/tables.md"
                 );
-                commonmark!("n12", ui, &mut self.cache, "------------");
+                commonmark!(ui, &mut self.cache, "------------");
 
                 commonmark_str!(
-                    "n13",
                     ui,
                     &mut self.cache,
                     "egui_commonmark/examples/markdown/definition_list.md"
                 );
-                commonmark!("n14", ui, &mut self.cache, "------------");
+                commonmark!(ui, &mut self.cache, "------------");
             });
         });
     }

--- a/egui_commonmark/examples/markdown/tables.md
+++ b/egui_commonmark/examples/markdown/tables.md
@@ -7,3 +7,12 @@ item a2 | item b2
 item a3 | item b3
 item a4 | item b4
 
+
+
+
+Column A   | Column B
+-----------|----------
+`item` `a1` | item b1
+item a2 | item b2
+item a3 | item b3
+item a4 | item b4

--- a/egui_commonmark/examples/mixing.rs
+++ b/egui_commonmark/examples/mixing.rs
@@ -10,7 +10,7 @@ macro_rules! m {
         }
         #[cfg(not(feature = "macros"))]
         {
-            egui_commonmark::CommonMarkViewer::new("viewer").show($ui, &mut $cache, $a);
+            egui_commonmark::CommonMarkViewer::new().show($ui, &mut $cache, $a);
         }
         )*
     };

--- a/egui_commonmark/examples/mixing.rs
+++ b/egui_commonmark/examples/mixing.rs
@@ -6,7 +6,7 @@ macro_rules! m {
         $ui.label("Label!");
         #[cfg(feature = "macros")]
         {
-            egui_commonmark_macros::commonmark!("n1", $ui, &mut $cache, $a);
+            egui_commonmark_macros::commonmark!($ui, &mut $cache, $a);
         }
         #[cfg(not(feature = "macros"))]
         {

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -35,9 +35,9 @@ vec.push(5);
         text += &repeating.repeat(1024);
 
         egui::CentralPanel::default().show(ctx, |ui| {
-            CommonMarkViewer::new("viewer")
+            CommonMarkViewer::new()
                 .max_image_width(Some(512))
-                .show_scrollable(ui, &mut self.cache, &text);
+                .show_scrollable("viewer", ui, &mut self.cache, &text);
         });
     }
 }

--- a/egui_commonmark/examples/show_mut.rs
+++ b/egui_commonmark/examples/show_mut.rs
@@ -18,9 +18,11 @@ impl eframe::App for App {
                         .code_editor()
                         .desired_width(f32::INFINITY),
                 );
-                CommonMarkViewer::new("viewer")
-                    .max_image_width(Some(512))
-                    .show_mut(ui, &mut self.cache, &mut self.text_buffer);
+                CommonMarkViewer::new().max_image_width(Some(512)).show_mut(
+                    ui,
+                    &mut self.cache,
+                    &mut self.text_buffer,
+                );
             });
         });
     }

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! # __run_test_ui(|ui| {
 //! let mut cache = CommonMarkCache::default();
-//! CommonMarkViewer::new("viewer").show(ui, &mut cache, markdown);
+//! CommonMarkViewer::new().show(ui, &mut cache, markdown);
 //! # });
 //!
 //! ```
@@ -47,7 +47,7 @@
 //! use egui_commonmark::{CommonMarkCache, commonmark};
 //! # egui::__run_test_ui(|ui| {
 //! let mut cache = CommonMarkCache::default();
-//! let _response = commonmark!( ui, &mut cache, "# ATX Heading Level 1");
+//! let _response = commonmark!(ui, &mut cache, "# ATX Heading Level 1");
 //! # });
 //! ```
 //!
@@ -88,14 +88,12 @@ use egui_commonmark_backend::*;
 
 #[derive(Debug)]
 pub struct CommonMarkViewer {
-    source_id: Id,
     options: CommonMarkOptions,
 }
 
 impl CommonMarkViewer {
-    pub fn new(source_id: impl std::hash::Hash) -> Self {
+    pub fn new() -> Self {
         Self {
-            source_id: Id::new(source_id),
             options: CommonMarkOptions::default(),
         }
     }
@@ -133,7 +131,7 @@ impl CommonMarkViewer {
     /// # Example
     /// ```
     /// # use egui_commonmark::CommonMarkViewer;
-    /// CommonMarkViewer::new("viewer").default_implicit_uri_scheme("https://example.org/");
+    /// CommonMarkViewer::new().default_implicit_uri_scheme("https://example.org/");
     /// ```
     pub fn default_implicit_uri_scheme<S: Into<String>>(mut self, scheme: S) -> Self {
         self.options.default_implicit_uri_scheme = scheme.into();
@@ -181,12 +179,12 @@ impl CommonMarkViewer {
     ) -> egui::InnerResponse<()> {
         egui_commonmark_backend::prepare_show(cache, ui.ctx());
 
-        let (response, _) = parsers::pulldown::CommonMarkViewerInternal::new(self.source_id).show(
+        let (response, _) = parsers::pulldown::CommonMarkViewerInternal::new().show(
             ui,
             cache,
             &self.options,
             text,
-            false,
+            None,
         );
 
         response
@@ -204,10 +202,13 @@ impl CommonMarkViewer {
         self.options.mutable = true;
         egui_commonmark_backend::prepare_show(cache, ui.ctx());
 
-        let (response, checkmark_events) = parsers::pulldown::CommonMarkViewerInternal::new(
-            self.source_id,
-        )
-        .show(ui, cache, &self.options, text, false);
+        let (response, checkmark_events) = parsers::pulldown::CommonMarkViewerInternal::new().show(
+            ui,
+            cache,
+            &self.options,
+            text,
+            None,
+        );
 
         // Update source text for checkmarks that were clicked
         for ev in checkmark_events {
@@ -236,9 +237,16 @@ impl CommonMarkViewer {
     /// [`show`]: crate::CommonMarkViewer::show
     #[doc(hidden)] // Buggy in scenarios more complex than the example application
     #[cfg(feature = "pulldown_cmark")]
-    pub fn show_scrollable(self, ui: &mut egui::Ui, cache: &mut CommonMarkCache, text: &str) {
+    pub fn show_scrollable(
+        self,
+        source_id: impl std::hash::Hash,
+        ui: &mut egui::Ui,
+        cache: &mut CommonMarkCache,
+        text: &str,
+    ) {
         egui_commonmark_backend::prepare_show(cache, ui.ctx());
-        parsers::pulldown::CommonMarkViewerInternal::new(self.source_id).show_scrollable(
+        parsers::pulldown::CommonMarkViewerInternal::new().show_scrollable(
+            Id::new(source_id),
             ui,
             cache,
             &self.options,

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -86,16 +86,14 @@ pub use egui_commonmark_backend;
 
 use egui_commonmark_backend::*;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CommonMarkViewer {
     options: CommonMarkOptions,
 }
 
 impl CommonMarkViewer {
     pub fn new() -> Self {
-        Self {
-            options: CommonMarkOptions::default(),
-        }
+        Self::default()
     }
 
     /// The amount of spaces a bullet point is indented. By default this is 4

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -47,7 +47,7 @@
 //! use egui_commonmark::{CommonMarkCache, commonmark};
 //! # egui::__run_test_ui(|ui| {
 //! let mut cache = CommonMarkCache::default();
-//! let _response = commonmark!("example", ui, &mut cache, "# ATX Heading Level 1");
+//! let _response = commonmark!( ui, &mut cache, "# ATX Heading Level 1");
 //! # });
 //! ```
 //!
@@ -60,7 +60,7 @@
 //! use egui_commonmark::{CommonMarkCache, commonmark_str};
 //! # egui::__run_test_ui(|ui| {
 //! let mut cache = CommonMarkCache::default();
-//! commonmark_str!("example_file", ui, &mut cache, "content.md");
+//! commonmark_str!(ui, &mut cache, "content.md");
 //! # });
 //! ```
 //!

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -426,7 +426,7 @@ impl CommonMarkViewerInternal {
         if self.is_table {
             self.line.try_insert_start(ui);
 
-            let id = self.source_id.with(self.curr_table);
+            let id = ui.id().with("_table").with(self.curr_table);
             self.curr_table += 1;
 
             egui::Frame::group(ui.style()).show(ui, |ui| {

--- a/egui_commonmark_macros/tests/fail/commonmark_str_not_found.rs
+++ b/egui_commonmark_macros/tests/fail/commonmark_str_not_found.rs
@@ -5,6 +5,6 @@ use egui_commonmark_macros::commonmark_str;
 fn main() {
     let mut cache = egui_commonmark_backend::CommonMarkCache::default();
     __run_test_ui(|ui| {
-        commonmark_str!("a", ui, &mut cache, "foo.md");
+        commonmark_str!(ui, &mut cache, "foo.md");
     });
 }

--- a/egui_commonmark_macros/tests/fail/commonmark_str_not_found.stderr
+++ b/egui_commonmark_macros/tests/fail/commonmark_str_not_found.stderr
@@ -1,5 +1,5 @@
 error: Could not find markdown file
- --> tests/fail/commonmark_str_not_found.rs:8:46
+ --> tests/fail/commonmark_str_not_found.rs:8:41
   |
-8 |         commonmark_str!("a", ui, &mut cache, "foo.md");
-  |                                              ^^^^^^^^
+8 |         commonmark_str!(ui, &mut cache, "foo.md");
+  |                                         ^^^^^^^^

--- a/egui_commonmark_macros/tests/fail/incorrect_immutable.rs
+++ b/egui_commonmark_macros/tests/fail/incorrect_immutable.rs
@@ -4,6 +4,6 @@ use egui_commonmark_macros::commonmark;
 fn main() {
     let mut cache = egui_commonmark_backend::CommonMarkCache::default();
     egui::__run_test_ui(|ui| {
-        commonmark!("a", ui, &cache, "# Hello");
+        commonmark!(ui, &cache, "# Hello");
     });
 }

--- a/egui_commonmark_macros/tests/fail/incorrect_immutable.stderr
+++ b/egui_commonmark_macros/tests/fail/incorrect_immutable.stderr
@@ -1,10 +1,10 @@
 error[E0308]: mismatched types
- --> tests/fail/incorrect_immutable.rs:7:30
+ --> tests/fail/incorrect_immutable.rs:7:25
   |
-7 |         commonmark!("a", ui, &cache, "# Hello");
-  |         ---------------------^^^^^^------------
-  |         |                    |
-  |         |                    types differ in mutability
+7 |         commonmark!(ui, &cache, "# Hello");
+  |         ----------------^^^^^^------------
+  |         |               |
+  |         |               types differ in mutability
   |         arguments to this function are incorrect
   |
   = note: expected mutable reference `&mut CommonMarkCache`

--- a/egui_commonmark_macros/tests/fail/incorrect_type.rs
+++ b/egui_commonmark_macros/tests/fail/incorrect_type.rs
@@ -4,5 +4,5 @@ use egui_commonmark_macros::commonmark;
 fn main() {
     let mut cache = egui_commonmark_backend::CommonMarkCache::default();
     let x = 3;
-    commonmark!("a", x, &mut cache, "# Hello");
+    commonmark!(x, &mut cache, "# Hello");
 }

--- a/egui_commonmark_macros/tests/fail/incorrect_type.stderr
+++ b/egui_commonmark_macros/tests/fail/incorrect_type.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
- --> tests/fail/incorrect_type.rs:7:22
+ --> tests/fail/incorrect_type.rs:7:17
   |
-7 |     commonmark!("a", x, &mut cache, "# Hello");
-  |     -----------------^------------------------
-  |     |                |
-  |     |                expected `&mut Ui`, found integer
+7 |     commonmark!(x, &mut cache, "# Hello");
+  |     ------------^------------------------
+  |     |           |
+  |     |           expected `&mut Ui`, found integer
   |     expected due to this

--- a/egui_commonmark_macros/tests/pass/book.rs
+++ b/egui_commonmark_macros/tests/pass/book.rs
@@ -6,45 +6,44 @@ fn main() {
     let mut cache = egui_commonmark_backend::CommonMarkCache::default();
     __run_test_ui(|ui| {
         commonmark_str!(
-            "n2",
             ui,
             &mut cache,
             "../../../../egui_commonmark/examples/markdown/hello_world.md"
         );
 
         commonmark_str!(
-            "n3",
             ui,
             &mut cache,
             "../../../../egui_commonmark/examples/markdown/headers.md"
         );
 
         commonmark_str!(
-            "n6",
             ui,
             &mut cache,
             "../../../../egui_commonmark/examples/markdown/lists.md"
         );
 
         commonmark_str!(
-            "n7",
             ui,
             &mut cache,
             "../../../../egui_commonmark/examples/markdown/code-blocks.md"
         );
 
         commonmark_str!(
-            "n9",
             ui,
             &mut cache,
             "../../../../egui_commonmark/examples/markdown/blockquotes.md"
         );
 
         commonmark_str!(
-            "n11",
             ui,
             &mut cache,
             "../../../../egui_commonmark/examples/markdown/tables.md"
+        );
+        commonmark_str!(
+            ui,
+            &mut cache,
+            "../../../../egui_commonmark/examples/markdown/definition_list.md"
         );
     });
 }

--- a/egui_commonmark_macros/tests/pass/commonmark.rs
+++ b/egui_commonmark_macros/tests/pass/commonmark.rs
@@ -5,6 +5,6 @@ use egui_commonmark_macros::commonmark;
 fn main() {
     let mut cache = egui_commonmark_backend::CommonMarkCache::default();
     __run_test_ui(|ui| {
-        let _response: egui::InnerResponse<()> = commonmark!("a", ui, &mut cache, "# Hello, World");
+        let _response: egui::InnerResponse<()> = commonmark!(ui, &mut cache, "# Hello, World");
     });
 }

--- a/egui_commonmark_macros/tests/pass/commonmark_str.rs
+++ b/egui_commonmark_macros/tests/pass/commonmark_str.rs
@@ -6,7 +6,6 @@ fn main() {
     let mut cache = egui_commonmark_backend::CommonMarkCache::default();
     __run_test_ui(|ui| {
         let _response: egui::InnerResponse<()> = commonmark_str!(
-            "a",
             ui,
             &mut cache,
             "../../../../egui_commonmark_macros/tests/file.md"

--- a/egui_commonmark_macros/tests/pass/ui_hygiene.rs
+++ b/egui_commonmark_macros/tests/pass/ui_hygiene.rs
@@ -7,7 +7,7 @@ fn main() {
     __run_test_ui(|ui| {
         egui::ScrollArea::vertical().show(ui, |ui| {
             egui::Frame::none().show(ui, |not_named_ui| {
-                commonmark!("a", not_named_ui, &mut cache, "# Hello, World");
+                commonmark!(not_named_ui, &mut cache, "# Hello, World");
             })
         });
     });


### PR DESCRIPTION
Closes #55

Over time the need for the id has been reduced and it should be possible to remove it for the normal use case now. While the Id was not too much of an issue for the CommonMark::show function it was a major PITA for the macro's usability.