### PR TITLE
Update egui to 0.30 and Rust to 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ resolver = "2"
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"                                        # Follows egui
+rust-version = "1.80"                                     # Follows egui
 version = "0.18.0"
 repository = "https://github.com/lampsitter/egui_commonmark"
 
 [workspace.dependencies]
-egui_extras = { version = "0.29", default-features = false }
-egui = { version = "0.29", default-features = false }
+egui_extras = { version = "0.30", default-features = false }
+egui = { version = "0.30", default-features = false }
 
 egui_commonmark_backend = { version = "0.18.0", path = "egui_commonmark_backend", default-features = false }
 egui_commonmark_macros = { version = "0.18.0", path = "egui_commonmark_macros", default-features = false }

--- a/egui_commonmark/Cargo.toml
+++ b/egui_commonmark/Cargo.toml
@@ -69,6 +69,7 @@ embedded_image = ["egui_commonmark_backend/embedded_image"]
 eframe = { version = "0.30", default-features = false, features = ["default_fonts", "glow"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 egui_commonmark_macros = { workspace = true } # Tests won't build otherswise
+home = "0.5.9"  # pinned for Rust 1.80.0, keep in sync with eframe
 
 [package.metadata.docs.rs]
 features = ["better_syntax_highlighting", "document-features", "macros"]

--- a/egui_commonmark/Cargo.toml
+++ b/egui_commonmark/Cargo.toml
@@ -66,7 +66,7 @@ fetch = ["egui_extras/http"]
 embedded_image = ["egui_commonmark_backend/embedded_image"]
 
 [dev-dependencies]
-eframe = { version = "0.30", default-features = false, features = ["default_fonts", "glow"] }
+eframe = { version = "0.30", default-features = false, features = ["default_fonts", "glow", "wayland", "x11"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 egui_commonmark_macros = { workspace = true } # Tests won't build otherswise
 home = "=0.5.9"  # pinned for Rust 1.80.0, keep in sync with eframe

--- a/egui_commonmark/Cargo.toml
+++ b/egui_commonmark/Cargo.toml
@@ -69,7 +69,7 @@ embedded_image = ["egui_commonmark_backend/embedded_image"]
 eframe = { version = "0.30", default-features = false, features = ["default_fonts", "glow"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 egui_commonmark_macros = { workspace = true } # Tests won't build otherswise
-home = "0.5.9"  # pinned for Rust 1.80.0, keep in sync with eframe
+home = "=0.5.9"  # pinned for Rust 1.80.0, keep in sync with eframe
 
 [package.metadata.docs.rs]
 features = ["better_syntax_highlighting", "document-features", "macros"]

--- a/egui_commonmark/Cargo.toml
+++ b/egui_commonmark/Cargo.toml
@@ -66,7 +66,7 @@ fetch = ["egui_extras/http"]
 embedded_image = ["egui_commonmark_backend/embedded_image"]
 
 [dev-dependencies]
-eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
+eframe = { version = "0.30", default-features = false, features = ["default_fonts", "glow"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 egui_commonmark_macros = { workspace = true } # Tests won't build otherswise
 

--- a/egui_commonmark_macros/Cargo.toml
+++ b/egui_commonmark_macros/Cargo.toml
@@ -20,7 +20,7 @@ include = ["src/**/*.rs", "LICENSE-MIT", "LICENSE-APACHE", "Cargo.toml"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "2", features = ["full"] }
+syn = "2"
 quote = { version = "1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
 

--- a/egui_commonmark_macros/Cargo.toml
+++ b/egui_commonmark_macros/Cargo.toml
@@ -20,7 +20,7 @@ include = ["src/**/*.rs", "LICENSE-MIT", "LICENSE-APACHE", "Cargo.toml"]
 proc-macro = true
 
 [dependencies]
-syn = "2"
+syn = { version = "2", features = ["full"] }
 quote = { version = "1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.80.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This PR updates egui to 0.30 and Rust to 1.80 (the latter because it is required by the former).