### PR TITLE
Scroll to heading functionality

### DIFF
--- a/egui_commonmark/examples/book.rs
+++ b/egui_commonmark/examples/book.rs
@@ -53,6 +53,7 @@ impl App {
                     CommonMarkViewer::new()
                         .default_width(Some(200))
                         .max_image_width(Some(512))
+                        .enable_scroll_to_heading(true)
                         .show(
                             ui,
                             &mut self.cache,
@@ -103,6 +104,10 @@ fn main() -> eframe::Result {
                     Page {
                         name: "Headers".to_owned(),
                         content: include_str!("markdown/headers.md").to_owned(),
+                    },
+                    Page {
+                        name: "Scroll to heading".to_owned(),
+                        content: include_str!("markdown/scroll_to_heading.md").to_owned(),
                     },
                     Page {
                         name: "Lists".to_owned(),

--- a/egui_commonmark/examples/markdown/scroll_to_heading.md
+++ b/egui_commonmark/examples/markdown/scroll_to_heading.md
@@ -1,0 +1,68 @@
+# Contents {#contents}
+
+- [Heading 1](#heading1)
+- [Heading 2](#heading2)
+- [Heading 3](#heading3)
+- [Heading 4](#heading4)
+- [Heading 5](#heading5)
+- [Heading 6](#heading6)
+
+# Heading 1 {#heading1}
+
+[back to contents](#contents)
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+## Heading 2 {#heading2}
+
+[back to contents](#contents)
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+### Heading 3 {#heading3}
+
+[back to contents](#contents)
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+#### Heading 4 {#heading4}
+
+[back to contents](#contents)
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+##### Heading 5 {#heading5}
+
+[back to contents](#contents)
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+###### Heading 6 {#heading6}
+
+[back to contents](#contents)
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -225,6 +225,13 @@ impl<'f> CommonMarkViewer<'f> {
         self
     }
 
+    /// Enable scrolling to headings by their ID.
+    /// To give a heading an ID, use the syntax `# Heading {#myheadingid}`. Then links to `#myheadingid` e.g. `[click me!](#myheadingid)` will scroll to that heading.
+    pub fn enable_scroll_to_heading(mut self, enable: bool) -> Self {
+        self.options.enable_scroll_to_heading = enable;
+        self
+    }
+
     /// Shows rendered markdown
     pub fn show(
         self,

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -83,6 +83,7 @@ pub struct CommonMarkViewerInternal {
     is_table: bool,
     is_blockquote: bool,
     checkbox_events: Vec<CheckboxClickEvent>,
+    deferred_scroll_to_heading: Option<String>,
 }
 
 pub(crate) struct CheckboxClickEvent {
@@ -106,16 +107,23 @@ impl CommonMarkViewerInternal {
             is_table: false,
             is_blockquote: false,
             checkbox_events: Vec::new(),
+            deferred_scroll_to_heading: None,
         }
     }
 }
 
-fn parser_options_math(is_math_enabled: bool) -> pulldown_cmark::Options {
+fn parser_options_extras(
+    is_math_enabled: bool,
+    is_scroll_to_heading_enabled: bool,
+) -> pulldown_cmark::Options {
+    let mut result = parser_options();
     if is_math_enabled {
-        parser_options() | pulldown_cmark::Options::ENABLE_MATH
-    } else {
-        parser_options()
+        result |= pulldown_cmark::Options::ENABLE_MATH;
     }
+    if is_scroll_to_heading_enabled {
+        result |= pulldown_cmark::Options::ENABLE_HEADING_ATTRIBUTES;
+    }
+    result
 }
 
 impl CommonMarkViewerInternal {
@@ -139,7 +147,7 @@ impl CommonMarkViewerInternal {
 
             let mut events = pulldown_cmark::Parser::new_ext(
                 text,
-                parser_options_math(options.math_fn.is_some()),
+                parser_options_extras(options.math_fn.is_some(), options.enable_scroll_to_heading),
             )
             .into_offset_iter()
             .enumerate()
@@ -179,6 +187,9 @@ impl CommonMarkViewerInternal {
                 }
             }
 
+            // deferral to make it consistent no matter whether the target is before or after the link
+            *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
+
             if let Some(source_id) = split_points_id {
                 scroll_cache(cache, &source_id).page_size =
                     Some(ui.next_widget_position().to_vec2());
@@ -211,10 +222,12 @@ impl CommonMarkViewerInternal {
             return;
         };
 
-        let events =
-            pulldown_cmark::Parser::new_ext(text, parser_options_math(options.math_fn.is_some()))
-                .into_offset_iter()
-                .collect::<Vec<_>>();
+        let events = pulldown_cmark::Parser::new_ext(
+            text,
+            parser_options_extras(options.math_fn.is_some(), options.enable_scroll_to_heading),
+        )
+        .into_offset_iter()
+        .collect::<Vec<_>>();
 
         let num_rows = events.len();
 
@@ -514,7 +527,7 @@ impl CommonMarkViewerInternal {
         max_width: f32,
     ) {
         match event {
-            pulldown_cmark::Event::Start(tag) => self.start_tag(ui, tag, options),
+            pulldown_cmark::Event::Start(tag) => self.start_tag(ui, tag, cache, options),
             pulldown_cmark::Event::End(tag) => self.end_tag(ui, tag, cache, options, max_width),
             pulldown_cmark::Event::Text(text) => {
                 self.event_text(text, ui);
@@ -587,12 +600,26 @@ impl CommonMarkViewerInternal {
         }
     }
 
-    fn start_tag(&mut self, ui: &mut Ui, tag: pulldown_cmark::Tag, options: &CommonMarkOptions) {
+    fn start_tag(
+        &mut self,
+        ui: &mut Ui,
+        tag: pulldown_cmark::Tag,
+        cache: &mut CommonMarkCache,
+        options: &CommonMarkOptions,
+    ) {
         match tag {
             pulldown_cmark::Tag::Paragraph => {
                 self.line.try_insert_start(ui);
             }
-            pulldown_cmark::Tag::Heading { level, .. } => {
+            pulldown_cmark::Tag::Heading { level, id, .. } => {
+                if let Some(scroll_target) = cache.scroll_to_id_target()
+                    && let Some(id) = id
+                    && id.into_string() == scroll_target
+                {
+                    ui.scroll_to_cursor(Some(egui::Align::TOP));
+                    cache.scroll_to_id_target_mut().take();
+                }
+
                 // Headings should always insert a newline even if it is at the start.
                 // Whether this is okay in all scenarios is a different question.
                 newline(ui);
@@ -763,7 +790,7 @@ impl CommonMarkViewerInternal {
             }
             pulldown_cmark::TagEnd::Link => {
                 if let Some(link) = self.link.take() {
-                    link.end(ui, cache);
+                    link.end(ui, cache, options, &mut self.deferred_scroll_to_heading);
                 }
             }
             pulldown_cmark::TagEnd::Image => {

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -33,6 +33,9 @@ pub struct CommonMarkOptions<'f> {
     pub mutable: bool,
     pub math_fn: Option<&'f crate::RenderMathFn>,
     pub html_fn: Option<&'f crate::RenderHtmlFn>,
+    /// Whether to enable scrolling to headings by their ID.
+    /// To give a heading an ID, use the syntax `# Heading {#myheadingid}`. Then links to `#myheadingid` e.g. `[click me!](#myheadingid)` will scroll to that heading.
+    pub enable_scroll_to_heading: bool,
 }
 
 impl std::fmt::Debug for CommonMarkOptions<'_> {
@@ -76,6 +79,7 @@ impl Default for CommonMarkOptions<'_> {
             mutable: false,
             math_fn: None,
             html_fn: None,
+            enable_scroll_to_heading: false,
         }
     }
 }
@@ -194,7 +198,13 @@ pub struct Link {
 }
 
 impl Link {
-    pub fn end(self, ui: &mut Ui, cache: &mut CommonMarkCache) {
+    pub fn end(
+        self,
+        ui: &mut Ui,
+        cache: &mut CommonMarkCache,
+        options: &CommonMarkOptions,
+        scroll_to_heading: &mut Option<String>,
+    ) {
         let Self { destination, text } = self;
 
         let mut layout_job = LayoutJob::default();
@@ -211,6 +221,12 @@ impl Link {
             if ui_link.clicked() || ui_link.middle_clicked() {
                 cache.link_hooks_mut().insert(destination, true);
             }
+        } else if options.enable_scroll_to_heading
+            && let Some(stripped) = destination.strip_prefix("#")
+        {
+            if ui.link(layout_job).clicked() {
+                scroll_to_heading.replace(stripped.to_string());
+            };
         } else {
             ui.hyperlink_to(layout_job, destination);
         }
@@ -413,6 +429,8 @@ pub struct CommonMarkCache {
     #[cfg(feature = "better_syntax_highlighting")]
     ts: ThemeSet,
 
+    /// The ID of the heading to scroll to. This is set when a link whose destination is a fragment (e.g. `#my-heading`) has been clicked.
+    scroll_to_id_target: Option<String>,
     link_hooks: HashMap<String, bool>,
 
     scroll: HashMap<egui::Id, ScrollableCache>,
@@ -429,6 +447,7 @@ impl Default for CommonMarkCache {
             ts: ThemeSet::load_defaults(),
             link_hooks: HashMap::new(),
             scroll: Default::default(),
+            scroll_to_id_target: None,
             has_installed_loaders: false,
         }
     }
@@ -479,6 +498,16 @@ impl CommonMarkCache {
             .themes
             .insert(name.into(), ThemeSet::load_from_reader(&mut cursor)?);
         Ok(())
+    }
+
+    /// Get the desired fragment. This is the id which will be scrolled to if it is found in the markdown.
+    pub fn scroll_to_id_target(&self) -> Option<&str> {
+        self.scroll_to_id_target.as_deref()
+    }
+
+    /// Get mutable access to the desired fragment. Setting this will cause the viewer to scroll to the heading with this id if it exists. Setting it to None will prevent scrolling.
+    pub fn scroll_to_id_target_mut(&mut self) -> &mut Option<String> {
+        &mut self.scroll_to_id_target
     }
 
     /// Clear the cache for all scrollable elements

--- a/egui_commonmark_macros/src/generator.rs
+++ b/egui_commonmark_macros/src/generator.rs
@@ -778,7 +778,7 @@ impl CommonMarkViewerInternal {
                     egui_commonmark_backend::Link {
                         destination: #destination.to_owned(),
                         text: vec![#text_stream]
-                    }.end(ui, #cache);)
+                    }.end(ui, #cache, &options, &mut None);)
                 } else {
                     TokenStream::new()
                 }


### PR DESCRIPTION
An example of using it is in the book example.

It allows you to scroll to a heading by specifying the heading's ID with the heading annotation syntax supported by pulldown-cmark, so that you may scroll to the heading `# My Heading {#my-heading}` by clicking `[click me!](#my-heading)`.