### PR TITLE
Speed up rendering >20x for large amounts of text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,9 +508,9 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "ecolor"
-version = "0.34.0"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb993f120d46ca077a18f166175b94c6edeb994d812cbd07a4a03cfced2713c"
+checksum = "a05fbfa222ffb51989d5ccf33e5f7aebfcf96c5023413856b0c3618a7f79896e"
 dependencies = [
  "bytemuck",
  "emath",
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.34.0"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd6562766ec6b921232ceb960acdb405f91971f59c17604840fd9485fee0dc3"
+checksum = "f98fe83b2589105b69dd25ca1e0fa2135a6e864d502fd8e08978f937e128cfef"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.34.0"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b71aaacbe69e214aebf7b8d5eacd6256d0d2ca5ff9525c28d1dd7f377f430a9"
+checksum = "42112be0ae157289312b92b3dfaf20e911b5a3c4c65d4aab0e7c47fbc0ce16e3"
 dependencies = [
  "accesskit",
  "ahash",
@@ -571,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.34.0"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111e54ac54bf9d767ce8970a454f720878875bca1f2e63f781c722e98f466971"
+checksum = "9f0c0559ac5598a1b887a6206dccbab7e3e6246c57cb00ae287262bd44776c9c"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.34.0"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6af7dad7dd045b77731fe6dc291b835489a104d3cd2428a945e71e2265df3"
+checksum = "967c5b323625d46d46a59b5daba3fef742248d27693cc18972458619858c4239"
 dependencies = [
  "arboard",
  "bytemuck",
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.34.0"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c5dea15932abd0a953fefc8d8490002204808a2e087147aac48608eea9ef79"
+checksum = "62b652957fa7e1ab01e8fecbfbf4e35f6e43a53fa98af8a562b50d5403cd44b9"
 dependencies = [
  "bytemuck",
  "egui",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "emath"
-version = "0.34.0"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8490360fc83eb3a2b20aba120457f7d91c3042d7c628e4f90b43a97b6adf1255"
+checksum = "b53f0d33a479321da6b0caa71366c9f67e8a2c149762d90bdc0d16e601ee8ecb"
 dependencies = [
  "bytemuck",
 ]
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.34.0"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76f9fdbf72eaf0dc3198d90e7bff267b45866f660f8cf49caeb9dcab93342e0"
+checksum = "6675898a291ec212fc3df04f537d177fce8496120244590e6359dcaa4c25da79"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.34.0"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1a65f42685d25419a67fd3175e11dfecdd268b0478aaba76785b0a896884e0"
+checksum = "f8970033a4282a7bcf899b38b5ed3a58b732fe093d03785d58648515d8d309da"
 
 [[package]]
 name = "equivalent"
@@ -1508,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b4372fed0bd362d646d01b6926df0e837859ccc522fed720c395e0460f29c8"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -3363,9 +3363,9 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9f386699b1fb8b8a05bfe82169b24d151f05702d2905a0bf93bc454fcc825"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.0",
@@ -3391,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c34181b0acb8f98168f78f8e57ec66f57df5522b39143dbe5f2f45d7ca927c"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -3431,9 +3431,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058b6047337cf323a4f092486443a9337f3d81325347e5d77deed7e563aeaedc"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -3452,9 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b8e1e505095f24cb4a578f04b1421d456257dca7fac114d9d9dd3d978c34b8"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -3462,9 +3462,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15ece45db77dd5451f11c0ce898334317ce8502d304a20454b531fdc0652fae"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,10 @@ pulldown-cmark = { version = "0.13", default-features = false }
 # eframe = { path = "../../egui/crates/eframe" }
 # egui = { path = "../../egui/crates/egui" }
 # egui_extras = { path = "../../egui/crates/egui_extras" }
+
+[profile.release]
+opt-level = 3     # Fast and small wasm
+lto = true        # Link Time Optimization
+codegen-units = 1 # Reduce number of codegen units to increase optimizations
+panic = 'abort'   # Abort on panic (smaller wasm size)
+strip = true      # Strip symbols from binary

--- a/egui_commonmark/examples/streaming.rs
+++ b/egui_commonmark/examples/streaming.rs
@@ -1,0 +1,249 @@
+//! Demonstrates incremental markdown rendering in `egui_commonmark`.
+//!
+//! This example simulates a live markdown stream by appending characters from a
+//! fixed source document every frame. It is useful for visually checking parser
+//! behavior during partial/incomplete input and for observing render/cache cost
+//! while content grows.
+//!
+//! Controls:
+//! - `Start at offset`: start streaming from an initial character position.
+//! - `Speed`: number of characters appended per frame.
+//! - `Play/Pause`: toggle continuous appending.
+//! - `Reset`: clear rendered content and restart from the selected offset.
+//! - `frame`: jump to a synthetic frame index for deterministic reproduction.
+
+use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
+use std::time::Instant;
+
+
+// The maximum number of frames (char appends) to simulate streaming.
+const MAX_FRAMES: usize = 10_000_000;
+
+struct StreamingApp {
+    state: StreamingState,
+    frame_idx: usize,
+    last_cache_regen_ms: f64,
+    offset_start_chars: usize,
+    chars_per_frame: usize,
+    is_playing: bool,
+}
+
+impl eframe::App for StreamingApp {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        if self.is_playing {
+            self.state.append_chars(self.chars_per_frame);
+        }
+
+        self.render_controls(ui);
+        let cache_regen_start = Instant::now();
+        self.render_markdown(ui);
+        self.last_cache_regen_ms = cache_regen_start.elapsed().as_secs_f64() * 1000.0;
+
+        if self.is_playing {
+            println!(
+                "frame {}: chars: {}, cache regen: {:.3} ms",
+                self.frame_idx, self.state.markdown.chars().count(), self.last_cache_regen_ms
+            );
+
+            self.frame_idx += 1;
+
+            // To make sure the UI is repainted to see the streaming changes.
+            ui.request_repaint();
+        }
+    }
+}
+
+impl StreamingApp {
+    fn render_controls(&mut self, ui: &mut egui::Ui) {
+        egui::Panel::top("streaming_top_panel").show_inside(ui, |ui| {
+            egui::Grid::new("streaming_controls_grid")
+                .num_columns(2)
+                .spacing([12.0, 8.0])
+                .show(ui, |ui| {
+                    ui.label("Start at offset:");
+                    ui.add(
+                        egui::Slider::new(
+                            &mut self.offset_start_chars,
+                            0..=self.state.source_char_len,
+                        )
+                        .show_value(true),
+                    );
+                    ui.end_row();
+
+                    ui.label("Speed:");
+                    ui.add(
+                        egui::Slider::new(&mut self.chars_per_frame, 1..=1_000).text("chars/frame"),
+                    );
+                    ui.end_row();
+                });
+            ui.horizontal(|ui| {
+                if ui
+                    .button(if self.is_playing { "Pause" } else { "Play" })
+                    .clicked()
+                {
+                    self.is_playing = !self.is_playing;
+                }
+                if ui.button("Reset").clicked() {
+                    self.state.reset(self.offset_start_chars);
+                    self.frame_idx = 0;
+                }
+
+                let frame_input = ui.add(
+                    egui::DragValue::new(&mut self.frame_idx)
+                        .prefix("frame: ")
+                        .speed(1.0)
+                        .range(0..=MAX_FRAMES),
+                );
+                if frame_input.changed() {
+                    self.state.seek_to_frame(
+                        self.offset_start_chars,
+                        self.chars_per_frame,
+                        self.frame_idx,
+                        MAX_FRAMES,
+                    );
+                }
+                ui.label(format!("chars: {}", self.state.markdown.chars().count()));
+                ui.label(format!("cache regen: {:.3} ms", self.last_cache_regen_ms));
+            });
+        });
+    }
+
+    fn render_markdown(&mut self, ui: &mut egui::Ui) {
+        egui::CentralPanel::default().show_inside(ui, |ui| {
+            egui::ScrollArea::vertical()
+                .id_salt(egui::Id::new("streaming_scroll"))
+                .auto_shrink([false, true])
+                .stick_to_bottom(true)
+                .show(ui, |ui| {
+                    CommonMarkViewer::new().show(ui, &mut self.state.cache, &self.state.markdown);
+                });
+        });
+    }
+}
+
+struct StreamingState {
+    cache: CommonMarkCache,
+    source: String,
+    markdown: String,
+    source_char_len: usize,
+    consumed_chars: usize,
+    consumed_bytes: usize,
+}
+
+impl StreamingState {
+    fn new(source: String) -> Self {
+        let source_char_len = source.chars().count();
+        let mut markdown = String::with_capacity(source.len());
+        markdown.push_str(&source);
+
+        Self {
+            cache: CommonMarkCache::default(),
+            source,
+            markdown,
+            source_char_len,
+            consumed_chars: 0,
+            consumed_bytes: 0,
+        }
+    }
+
+    fn reset(&mut self, initial_chars: usize) {
+        let initial_chars = initial_chars.min(self.source_char_len);
+        let initial_bytes = byte_index_for_char_count(&self.source, initial_chars);
+        self.cache = CommonMarkCache::default();
+        self.markdown.clear();
+        self.markdown.push_str(&self.source[..initial_bytes]);
+        self.consumed_chars = initial_chars;
+        self.consumed_bytes = initial_bytes;
+    }
+
+    fn append_chars(&mut self, count: usize) {
+        if self.source_char_len == 0 || count == 0 {
+            return;
+        }
+
+        let mut remaining = count;
+        while remaining > 0 {
+            if self.consumed_chars >= self.source_char_len {
+                self.consumed_chars = 0;
+                self.consumed_bytes = 0;
+            }
+
+            let available = self.source_char_len - self.consumed_chars;
+            let step = remaining.min(available);
+            let target_chars = self.consumed_chars + step;
+            let target_bytes = byte_index_for_char_count(&self.source, target_chars);
+
+            self.markdown
+                .push_str(&self.source[self.consumed_bytes..target_bytes]);
+            self.consumed_chars = target_chars;
+            self.consumed_bytes = target_bytes;
+            remaining -= step;
+        }
+    }
+
+    fn seek_to_frame(
+        &mut self,
+        start_chars: usize,
+        chars_per_frame: usize,
+        frame_idx: usize,
+        max_chars: usize,
+    ) {
+        let start = start_chars.min(self.source_char_len);
+        let appended = frame_idx.saturating_mul(chars_per_frame);
+        let target_total = start.saturating_add(appended).min(max_chars);
+        self.cache = CommonMarkCache::default();
+        self.markdown.clear();
+
+        if self.source_char_len == 0 {
+            self.consumed_chars = 0;
+            self.consumed_bytes = 0;
+            return;
+        }
+
+        let full_repeats = target_total / self.source_char_len;
+        let tail_chars = target_total % self.source_char_len;
+        for _ in 0..full_repeats {
+            self.markdown.push_str(&self.source);
+        }
+        let tail_bytes = byte_index_for_char_count(&self.source, tail_chars);
+        self.markdown.push_str(&self.source[..tail_bytes]);
+
+        self.consumed_chars = tail_chars;
+        self.consumed_bytes = tail_bytes;
+    }
+}
+
+/// Converts a character count into a valid UTF-8 byte index for `input`.
+///
+/// Streaming state is tracked in characters, but Rust string slicing uses byte
+/// offsets. This helper keeps slices on char boundaries to avoid panics.
+fn byte_index_for_char_count(input: &str, char_count: usize) -> usize {
+    if char_count == 0 {
+        return 0;
+    }
+
+    input
+        .char_indices()
+        .nth(char_count)
+        .map_or(input.len(), |(byte_index, _)| byte_index)
+}
+
+fn main() {
+    let source_markdown = include_str!("markdown/scroll_to_heading.md").to_owned();
+
+    eframe::run_native(
+        "egui_commonmark streaming example",
+        eframe::NativeOptions::default(),
+        Box::new(move |_cc| {
+            Ok(Box::new(StreamingApp {
+                state: StreamingState::new(source_markdown),
+                frame_idx: 0,
+                last_cache_regen_ms: 0.0,
+                offset_start_chars: 0,
+                chars_per_frame: 100,
+                is_playing: true,
+            }))
+        }),
+    )
+    .unwrap();
+}

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -47,7 +47,8 @@
 //! ## Example
 //!
 //! ```
-//! use egui_commonmark::{CommonMarkCache, commonmark};
+//! use egui_commonmark::{CommonMarkCache};
+//! use egui_commonmark_macros::{commonmark};
 //! # egui::__run_test_ui(|ui| {
 //! let mut cache = CommonMarkCache::default();
 //! let _response = commonmark!(ui, &mut cache, "# ATX Heading Level 1");
@@ -246,7 +247,7 @@ impl<'f> CommonMarkViewer<'f> {
             cache,
             &self.options,
             text,
-            None,
+            Some(ui.id().with("_show_virtualized")),
         );
 
         response
@@ -270,7 +271,7 @@ impl<'f> CommonMarkViewer<'f> {
                 cache,
                 &self.options,
                 text,
-                None,
+                Some(ui.id().with("_show_virtualized")),
             );
 
         // Update source text for checkmarks that were clicked
@@ -320,6 +321,7 @@ impl<'f> CommonMarkViewer<'f> {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct ListLevel {
     current_number: Option<u64>,
 }
@@ -349,6 +351,23 @@ impl List {
 
     pub fn is_last_level(&self) -> bool {
         self.items.len() == 1
+    }
+
+    pub(crate) fn checkpoint(&self) -> (Vec<Option<u64>>, bool) {
+        (
+            self.items.iter().map(|item| item.current_number).collect(),
+            self.has_list_begun,
+        )
+    }
+
+    pub(crate) fn from_checkpoint(current_numbers: Vec<Option<u64>>, has_list_begun: bool) -> Self {
+        Self {
+            items: current_numbers
+                .into_iter()
+                .map(|current_number| ListLevel { current_number })
+                .collect(),
+            has_list_begun,
+        }
     }
 
     pub fn start_item(&mut self, ui: &mut egui::Ui, options: &CommonMarkOptions) {

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -1,9 +1,10 @@
 use std::iter::Peekable;
 use std::ops::Range;
+use std::{cell::RefCell, collections::HashMap};
 
 use crate::{CommonMarkCache, CommonMarkOptions};
 
-use egui::{self, Id, Pos2, TextStyle, Ui};
+use egui::{self, Id, TextStyle, Ui};
 
 use crate::List;
 use egui_commonmark_backend::elements::*;
@@ -14,6 +15,7 @@ use pulldown_cmark::{CowStr, HeadingLevel};
 /// Newline logic is constructed by the following:
 /// All elements try to insert a newline before them (if they are allowed)
 /// and end their own line.
+#[derive(Clone)]
 struct Newline {
     /// Whether a newline should not be inserted before a widget. This is only for
     /// the first widget.
@@ -61,7 +63,7 @@ impl Newline {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct DefinitionList {
     is_first_item: bool,
     is_def_list_def: bool,
@@ -91,6 +93,45 @@ pub(crate) struct CheckboxClickEvent {
     pub(crate) span: Range<usize>,
 }
 
+const CHECKPOINT_STRIDE_EVENTS: usize = 4;
+const CHECKPOINT_OVERSCAN: usize = 0;
+
+#[derive(Clone)]
+struct RenderCheckpoint {
+    event_index: usize,
+    start_y: f32,
+    end_y: f32,
+    snapshot: RenderSnapshot,
+}
+
+#[derive(Clone)]
+struct RenderSnapshot {
+    curr_table: usize,
+    text_style: Style,
+    list_numbers: Vec<Option<u64>>,
+    list_has_begun: bool,
+    line: Newline,
+    is_list_item: bool,
+    def_list: DefinitionList,
+    is_table: bool,
+    is_blockquote: bool,
+}
+
+#[derive(Default)]
+struct LocalVirtualizationCache {
+    checkpoints: Vec<RenderCheckpoint>,
+    page_height: f32,
+    text_ptr: usize,
+    text_len: usize,
+    parser_options_bits: u32,
+    available_width_bits: u32,
+    just_changed: bool,
+}
+
+thread_local! {
+    static LOCAL_VIRTUAL_CACHE: RefCell<HashMap<Id, LocalVirtualizationCache>> = RefCell::new(HashMap::new());
+}
+
 impl CommonMarkViewerInternal {
     pub fn new() -> Self {
         Self {
@@ -110,6 +151,45 @@ impl CommonMarkViewerInternal {
             deferred_scroll_to_heading: None,
         }
     }
+
+    fn can_checkpoint(&self) -> bool {
+        self.link.is_none()
+            && self.image.is_none()
+            && self.code_block.is_none()
+            && self.html_block.is_empty()
+    }
+
+    fn snapshot(&self) -> RenderSnapshot {
+        let (list_numbers, list_has_begun) = self.list.checkpoint();
+        RenderSnapshot {
+            curr_table: self.curr_table,
+            text_style: self.text_style.clone(),
+            list_numbers,
+            list_has_begun,
+            line: self.line.clone(),
+            is_list_item: self.is_list_item,
+            def_list: self.def_list.clone(),
+            is_table: self.is_table,
+            is_blockquote: self.is_blockquote,
+        }
+    }
+
+    fn restore_from_snapshot(&mut self, snapshot: &RenderSnapshot) {
+        self.curr_table = snapshot.curr_table;
+        self.text_style = snapshot.text_style.clone();
+        self.list = List::from_checkpoint(snapshot.list_numbers.clone(), snapshot.list_has_begun);
+        self.line = snapshot.line.clone();
+        self.is_list_item = snapshot.is_list_item;
+        self.def_list = snapshot.def_list.clone();
+        self.is_table = snapshot.is_table;
+        self.is_blockquote = snapshot.is_blockquote;
+        self.link = None;
+        self.image = None;
+        self.code_block = None;
+        self.html_block.clear();
+        self.checkbox_events.clear();
+        self.deferred_scroll_to_heading = None;
+    }
 }
 
 fn parser_options_extras(
@@ -124,6 +204,124 @@ fn parser_options_extras(
         result |= pulldown_cmark::Options::ENABLE_HEADING_ATTRIBUTES;
     }
     result
+}
+
+fn clamp_to_char_boundary(text: &str, mut index: usize) -> usize {
+    if index > text.len() {
+        index = text.len();
+    }
+    while index > 0 && !text.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn fence_marker(line: &str) -> Option<(u8, usize)> {
+    let trimmed = line.trim_start_matches([' ', '\t']);
+    let indent = line.len().saturating_sub(trimmed.len());
+    if indent > 3 {
+        return None;
+    }
+    let bytes = trimmed.as_bytes();
+    if bytes.is_empty() {
+        return None;
+    }
+    let marker = bytes[0];
+    if marker != b'`' && marker != b'~' {
+        return None;
+    }
+    let run_len = bytes.iter().take_while(|b| **b == marker).count();
+    if run_len >= 3 {
+        Some((marker, run_len))
+    } else {
+        None
+    }
+}
+
+fn inside_unclosed_fence(prefix: &str) -> bool {
+    let mut current_fence: Option<(u8, usize)> = None;
+    for line in prefix.lines() {
+        if let Some((marker, run_len)) = fence_marker(line) {
+            if let Some((open_marker, open_len)) = current_fence {
+                if marker == open_marker && run_len >= open_len {
+                    current_fence = None;
+                }
+            } else {
+                current_fence = Some((marker, run_len));
+            }
+        }
+    }
+    current_fence.is_some()
+}
+
+fn incremental_reparse_start(text: &str, previous_len: usize) -> usize {
+    // Be conservative for correctness: reparse from the last blank-line boundary
+    // in a larger context window, since markdown block semantics can depend on
+    // lines before the append point.
+    let context_start = clamp_to_char_boundary(text, previous_len.saturating_sub(64 * 1024));
+    let window = &text[context_start..previous_len];
+    let candidate = if let Some(blank_line_pos) = window.rfind("\n\n") {
+        context_start + blank_line_pos + 2
+    } else if let Some(last_newline) = window.as_bytes().iter().rposition(|b| *b == b'\n') {
+        context_start + last_newline + 1
+    } else {
+        0
+    };
+
+    if candidate > 0 && inside_unclosed_fence(&text[..candidate]) {
+        0
+    } else {
+        candidate
+    }
+}
+
+fn width_cache_key(width: f32) -> u32 {
+    width.max(0.0).round() as u32
+}
+
+fn appended_text_needs_full_reparse(appended: &str) -> bool {
+    // Reference-style link / footnote definitions appended later can affect
+    // earlier inline parsing, so incremental tail-only reparsing is unsafe.
+    appended.lines().any(|line| {
+        let trimmed = line.trim_start_matches([' ', '\t']);
+        trimmed.starts_with('[') && trimmed.contains("]:")
+    })
+}
+
+fn try_incremental_append_parse(
+    scroll_cache: &mut ScrollableCache,
+    text: &str,
+    parser_options: pulldown_cmark::Options,
+    text_len: usize,
+) -> Option<usize> {
+    if scroll_cache.parsed_events.is_empty()
+        || scroll_cache.parser_options_bits != parser_options.bits()
+        || text_len <= scroll_cache.parsed_text_len
+    {
+        return None;
+    }
+
+    let previous_len = scroll_cache.parsed_text_len;
+    if appended_text_needs_full_reparse(&text[previous_len..text_len]) {
+        return None;
+    }
+    let reparse_start = incremental_reparse_start(text, previous_len);
+    scroll_cache
+        .parsed_events
+        .retain(|(_, span)| span.end <= reparse_start);
+    let changed_event_start = scroll_cache.parsed_events.len();
+
+    let reparsed_tail = pulldown_cmark::Parser::new_ext(&text[reparse_start..], parser_options)
+        .into_offset_iter()
+        .map(|(event, span)| {
+            (
+                event.into_static(),
+                (span.start + reparse_start)..(span.end + reparse_start),
+            )
+        });
+    scroll_cache.parsed_events.extend(reparsed_tail);
+    scroll_cache.parsed_text_len = text_len;
+    Some(changed_event_start)
 }
 
 impl CommonMarkViewerInternal {
@@ -144,55 +342,320 @@ impl CommonMarkViewerInternal {
             ui.spacing_mut().item_spacing.x = 0.0;
             let height = ui.text_style_height(&TextStyle::Body);
             ui.set_row_height(height);
+            let parser_options =
+                parser_options_extras(options.math_fn.is_some(), options.enable_scroll_to_heading);
+            let text_ptr = text.as_ptr() as usize;
+            let text_len = text.len();
+            let mut collect_checkpoints = false;
+            let mut top_spacer_height = 0.0_f32;
+            let mut bottom_spacer_height = 0.0_f32;
+            let mut restore_snapshot = None;
+            let mut collected_checkpoints = Vec::<RenderCheckpoint>::new();
+            let first_position_y = ui.next_widget_position().y;
+            let (indexed_events, total_event_count, text_changed_this_frame) =
+                if let Some(source_id) = split_points_id {
+                    let available_size = ui.available_size();
+                    let viewport = ui.clip_rect();
+                    let scroll_cache = scroll_cache(cache, &source_id);
+                    let size_changed = (scroll_cache.available_size.x - available_size.x).abs()
+                        > 0.5
+                        || (scroll_cache.available_size.y - available_size.y).abs() > 0.5;
+                    let mut changed_event_start = None;
 
-            let mut events = pulldown_cmark::Parser::new_ext(
-                text,
-                parser_options_extras(options.math_fn.is_some(), options.enable_scroll_to_heading),
-            )
-            .into_offset_iter()
-            .enumerate()
-            .peekable();
+                    let cache_is_stale = scroll_cache.parsed_text_ptr != text_ptr
+                        || scroll_cache.parsed_text_len != text_len
+                        || scroll_cache.parser_options_bits != parser_options.bits()
+                        || scroll_cache.parsed_events.is_empty()
+                        || size_changed;
+
+                    if cache_is_stale {
+                        changed_event_start = try_incremental_append_parse(
+                            scroll_cache,
+                            text,
+                            parser_options,
+                            text_len,
+                        );
+                        if changed_event_start.is_none() {
+                            scroll_cache.parsed_events =
+                                pulldown_cmark::Parser::new_ext(text, parser_options)
+                                    .into_offset_iter()
+                                    .map(|(event, span)| (event.into_static(), span))
+                                    .collect();
+                            changed_event_start = Some(0);
+                        }
+                        scroll_cache.parsed_text_ptr = text_ptr;
+                        scroll_cache.parsed_text_len = text_len;
+                        scroll_cache.parser_options_bits = parser_options.bits();
+                        scroll_cache.page_size = None;
+                        scroll_cache.split_points.clear();
+                    }
+
+                    let total_events = scroll_cache.parsed_events.len();
+                    let available_width_bits = width_cache_key(available_size.x);
+                    let local = LOCAL_VIRTUAL_CACHE.with(|cache_by_id| {
+                        let mut cache_by_id = cache_by_id.borrow_mut();
+                        cache_by_id.remove(&source_id).unwrap_or_default()
+                    });
+                    let text_changed = local.text_ptr != text_ptr || local.text_len != text_len;
+                    let text_appended = text_len > local.text_len;
+                    let stale_non_append_text = text_len < local.text_len
+                        || (text_len == local.text_len && local.text_ptr != text_ptr);
+                    let stale_parser = local.parser_options_bits != parser_options.bits();
+                    let stale_width = local.available_width_bits != available_width_bits;
+                    let stale_checkpoints = local.checkpoints.len() < 2;
+                    let stale_just_changed = !text_changed && local.just_changed;
+                    let local_is_stale = stale_non_append_text
+                        || stale_parser
+                        || stale_width
+                        || stale_checkpoints
+                        || stale_just_changed;
+                    let mut partial_rebuild_state: Option<(usize, Vec<RenderCheckpoint>)> = None;
+                    let mut append_offscreen_safe_reuse = false;
+                    if text_changed && text_appended && !local_is_stale {
+                        if let Some(changed_start) = changed_event_start {
+                            let viewport_max = viewport.max.y - first_position_y;
+                            let near_bottom = viewport_max >= (local.page_height - 1.0);
+                            let viewport_end_checkpoint_index = local
+                                .checkpoints
+                                .iter()
+                                .position(|checkpoint| checkpoint.start_y >= viewport_max)
+                                .unwrap_or(local.checkpoints.len().saturating_sub(1))
+                                .saturating_add(CHECKPOINT_OVERSCAN)
+                                .min(local.checkpoints.len().saturating_sub(1));
+                            let viewport_end_event_index = local.checkpoints
+                                [viewport_end_checkpoint_index]
+                                .event_index
+                                .min(total_events);
+                            let safety_margin_events = CHECKPOINT_STRIDE_EVENTS.saturating_mul(2);
+                            append_offscreen_safe_reuse = !near_bottom
+                                && changed_start
+                                    > viewport_end_event_index.saturating_add(safety_margin_events);
+                            let changed_rebuild_pos = local
+                                .checkpoints
+                                .iter()
+                                .rposition(|checkpoint| checkpoint.event_index <= changed_start);
+                            let viewport_min = viewport.min.y - first_position_y;
+                            let viewport_rebuild_pos = local
+                                .checkpoints
+                                .iter()
+                                .rposition(|checkpoint| checkpoint.end_y <= viewport_min)
+                                .unwrap_or(0)
+                                .saturating_sub(CHECKPOINT_OVERSCAN);
+                            if let Some(changed_rebuild_pos) = changed_rebuild_pos
+                                && !append_offscreen_safe_reuse
+                            {
+                                let rebuild_pos = changed_rebuild_pos.min(viewport_rebuild_pos);
+                                let rebuild_checkpoint = local.checkpoints[rebuild_pos].clone();
+                                top_spacer_height = rebuild_checkpoint.start_y.max(0.0);
+                                restore_snapshot = Some(rebuild_checkpoint.snapshot.clone());
+                                let prefix = local.checkpoints[..=rebuild_pos].to_vec();
+                                partial_rebuild_state =
+                                    Some((rebuild_checkpoint.event_index, prefix));
+                            }
+                        }
+                    }
+
+                    let events = if local_is_stale
+                        || (text_changed
+                            && partial_rebuild_state.is_none()
+                            && !append_offscreen_safe_reuse)
+                    {
+                        collect_checkpoints = true;
+                        collected_checkpoints.push(RenderCheckpoint {
+                            event_index: 0,
+                            start_y: 0.0,
+                            end_y: 0.0,
+                            snapshot: self.snapshot(),
+                        });
+                        scroll_cache.available_size = available_size;
+                        scroll_cache
+                            .parsed_events
+                            .iter()
+                            .cloned()
+                            .enumerate()
+                            .collect::<Vec<_>>()
+                    } else if let Some((rebuild_start_event_index, prefix_checkpoints)) =
+                        partial_rebuild_state
+                    {
+                        collect_checkpoints = true;
+                        collected_checkpoints = prefix_checkpoints;
+                        scroll_cache.available_size = available_size;
+                        scroll_cache
+                            .parsed_events
+                            .iter()
+                            .cloned()
+                            .enumerate()
+                            .skip(rebuild_start_event_index)
+                            .collect::<Vec<_>>()
+                    } else {
+                        let checkpoints = local.checkpoints;
+                        let viewport_min = viewport.min.y - first_position_y;
+                        let viewport_max = viewport.max.y - first_position_y;
+                        let start_checkpoint_index = checkpoints
+                            .iter()
+                            .rposition(|checkpoint| checkpoint.end_y <= viewport_min)
+                            .unwrap_or(0)
+                            .saturating_sub(CHECKPOINT_OVERSCAN);
+
+                        let end_checkpoint_index = checkpoints
+                            .iter()
+                            .position(|checkpoint| checkpoint.start_y >= viewport_max)
+                            .unwrap_or(checkpoints.len().saturating_sub(1))
+                            .saturating_add(CHECKPOINT_OVERSCAN)
+                            .min(checkpoints.len().saturating_sub(1));
+
+                        let start_checkpoint = &checkpoints[start_checkpoint_index];
+                        let end_checkpoint = &checkpoints[end_checkpoint_index];
+                        let start_event_index = start_checkpoint.event_index.min(total_events);
+                        let render_to_tail = text_appended && !append_offscreen_safe_reuse;
+                        let end_event_index = if render_to_tail {
+                            total_events
+                        } else {
+                            end_checkpoint
+                                .event_index
+                                .max(start_event_index)
+                                .min(total_events)
+                        };
+
+                        restore_snapshot = Some(start_checkpoint.snapshot.clone());
+                        top_spacer_height = start_checkpoint.start_y.max(0.0);
+                        bottom_spacer_height = if render_to_tail {
+                            0.0
+                        } else {
+                            (local.page_height - end_checkpoint.start_y).max(0.0)
+                        };
+
+                        let selected = scroll_cache
+                            .parsed_events
+                            .iter()
+                            .cloned()
+                            .enumerate()
+                            .skip(start_event_index)
+                            .take(end_event_index.saturating_sub(start_event_index))
+                            .collect::<Vec<_>>();
+                        LOCAL_VIRTUAL_CACHE.with(|cache_by_id| {
+                            cache_by_id.borrow_mut().insert(
+                                source_id,
+                                LocalVirtualizationCache {
+                                    checkpoints,
+                                    page_height: local.page_height,
+                                    text_ptr,
+                                    text_len,
+                                    parser_options_bits: parser_options.bits(),
+                                    available_width_bits,
+                                    just_changed: false,
+                                },
+                            );
+                        });
+
+                        selected
+                    };
+
+                    (events, total_events, text_changed)
+                } else {
+                    let events = pulldown_cmark::Parser::new_ext(text, parser_options)
+                        .into_offset_iter()
+                        .map(|(event, span)| (event.into_static(), span))
+                        .enumerate()
+                        .collect::<Vec<_>>();
+                    let total_events = events.len();
+                    (events, total_events, false)
+                };
+
+            if let Some(snapshot) = restore_snapshot.as_ref() {
+                self.restore_from_snapshot(snapshot);
+            }
+
+            if top_spacer_height > 0.0 {
+                ui.allocate_space(egui::vec2(0.0, top_spacer_height));
+            }
+
+            let mut events = indexed_events.into_iter().peekable();
 
             while let Some((index, (e, src_span))) = events.next() {
                 let start_position = ui.next_widget_position();
-                let is_element_end = matches!(e, pulldown_cmark::Event::End(_));
-                let should_add_split_point = self.list.is_inside_a_list() && is_element_end;
+                let should_checkpoint = collect_checkpoints
+                    && index > 0
+                    && index % CHECKPOINT_STRIDE_EVENTS == 0
+                    && collected_checkpoints
+                        .last()
+                        .is_none_or(|checkpoint| checkpoint.event_index != index)
+                    && self.can_checkpoint();
+                if should_checkpoint {
+                    collected_checkpoints.push(RenderCheckpoint {
+                        event_index: index,
+                        start_y: start_position.y - first_position_y,
+                        end_y: start_position.y - first_position_y,
+                        snapshot: self.snapshot(),
+                    });
+                }
 
-                if events.peek().is_none() {
+                if events.peek().is_none() && index + 1 == total_event_count {
                     self.line.should_end_newline_forced = false;
                 }
 
                 self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
 
-                if let Some(source_id) = split_points_id
-                    && should_add_split_point
-                {
-                    let scroll_cache = scroll_cache(cache, &source_id);
-                    let end_position = ui.next_widget_position();
-
-                    let split_point_exists = scroll_cache
-                        .split_points
-                        .iter()
-                        .any(|(i, _, _)| *i == index);
-
-                    if !split_point_exists {
-                        scroll_cache
-                            .split_points
-                            .push((index, start_position, end_position));
-                    }
-                }
-
                 if index == 0 {
                     self.line.should_not_start_newline_forced = false;
                 }
+            }
+            if bottom_spacer_height > 0.0 {
+                ui.allocate_space(egui::vec2(0.0, bottom_spacer_height));
             }
 
             // deferral to make it consistent no matter whether the target is before or after the link
             *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
 
             if let Some(source_id) = split_points_id {
-                scroll_cache(cache, &source_id).page_size =
-                    Some(ui.next_widget_position().to_vec2());
+                if collect_checkpoints {
+                    let page_size = ui.next_widget_position().to_vec2();
+                    let page_height = (page_size.y - first_position_y).max(0.0);
+                    let scroll_cache = scroll_cache(cache, &source_id);
+                    scroll_cache.page_size = Some(page_size);
+                    scroll_cache.split_points.clear();
+
+                    let total_events = scroll_cache.parsed_events.len();
+                    let mut checkpoints = collected_checkpoints;
+                    let needs_sentinel = checkpoints
+                        .last()
+                        .is_none_or(|checkpoint| checkpoint.event_index != total_events);
+                    if needs_sentinel {
+                        checkpoints.push(RenderCheckpoint {
+                            event_index: total_events,
+                            start_y: page_height,
+                            end_y: page_height,
+                            snapshot: self.snapshot(),
+                        });
+                    }
+                    for i in 0..checkpoints.len() {
+                        let next_start = checkpoints
+                            .get(i + 1)
+                            .map_or(page_height, |next| next.start_y);
+                        checkpoints[i].end_y = next_start;
+                    }
+
+                    let available_width_bits = width_cache_key(scroll_cache.available_size.x);
+                    LOCAL_VIRTUAL_CACHE.with(|cache_by_id| {
+                        cache_by_id.borrow_mut().insert(
+                            source_id,
+                            LocalVirtualizationCache {
+                                checkpoints,
+                                page_height,
+                                text_ptr,
+                                text_len,
+                                parser_options_bits: parser_options.bits(),
+                                available_width_bits,
+                                just_changed: text_changed_this_frame,
+                            },
+                        );
+                    });
+                } else if restore_snapshot.is_some() {
+                    let scroll_cache = scroll_cache(cache, &source_id);
+                    if scroll_cache.page_size.is_none() {
+                        scroll_cache.page_size = Some(ui.next_widget_position().to_vec2());
+                    }
+                }
             }
         });
 
@@ -210,87 +673,21 @@ impl CommonMarkViewerInternal {
         let available_size = ui.available_size();
         let scroll_id = source_id.with("_scroll_area");
 
-        let Some(page_size) = scroll_cache(cache, &source_id).page_size else {
-            egui::ScrollArea::vertical()
-                .id_salt(scroll_id)
-                .auto_shrink([false, true])
-                .show(ui, |ui| {
-                    self.show(ui, cache, options, text, Some(source_id));
-                });
-            // Prevent repopulating points twice at startup
-            scroll_cache(cache, &source_id).available_size = available_size;
-            return;
-        };
-
-        let events = pulldown_cmark::Parser::new_ext(
-            text,
-            parser_options_extras(options.math_fn.is_some(), options.enable_scroll_to_heading),
-        )
-        .into_offset_iter()
-        .collect::<Vec<_>>();
-
-        let num_rows = events.len();
-
         egui::ScrollArea::vertical()
             .id_salt(scroll_id)
             // Elements have different widths, so the scroll area cannot try to shrink to the
             // content, as that will mean that the scroll bar will move when loading elements
             // with different widths.
             .auto_shrink([false, true])
-            .show_viewport(ui, |ui, viewport| {
-                ui.set_height(page_size.y);
-                let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
-
-                let max_width = options.max_width(ui);
-                ui.allocate_ui_with_layout(egui::vec2(max_width, 0.0), layout, |ui| {
-                    ui.spacing_mut().item_spacing.x = 0.0;
-                    let scroll_cache = scroll_cache(cache, &source_id);
-
-                    // finding the first element that's not in the viewport anymore
-                    let (first_event_index, _, first_end_position) = scroll_cache
-                        .split_points
-                        .iter()
-                        .filter(|(_, _, end_position)| end_position.y < viewport.min.y)
-                        .nth_back(1)
-                        .copied()
-                        .unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
-
-                    // finding the last element that's just outside the viewport
-                    let last_event_index = scroll_cache
-                        .split_points
-                        .iter()
-                        .filter(|(_, start_position, _)| start_position.y > viewport.max.y)
-                        .nth(1)
-                        .map(|(index, _, _)| *index)
-                        .unwrap_or(num_rows);
-
-                    ui.allocate_space(first_end_position.to_vec2());
-
-                    // only rendering the elements that are inside the viewport
-                    let mut events = events
-                        .into_iter()
-                        .enumerate()
-                        .skip(first_event_index)
-                        .take(last_event_index - first_event_index)
-                        .peekable();
-
-                    while let Some((i, (e, src_span))) = events.next() {
-                        if events.peek().is_none() {
-                            self.line.should_end_newline_forced = false;
-                        }
-
-                        self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
-
-                        if i == 0 {
-                            self.line.should_not_start_newline_forced = false;
-                        }
-                    }
-                });
+            .show(ui, |ui| {
+                self.show(ui, cache, options, text, Some(source_id));
             });
 
         // Forcing full re-render to repopulate split points for the new size
         let scroll_cache = scroll_cache(cache, &source_id);
-        if available_size != scroll_cache.available_size {
+        if (available_size.x - scroll_cache.available_size.x).abs() > 0.5
+            || (available_size.y - scroll_cache.available_size.y).abs() > 0.5
+        {
             scroll_cache.available_size = available_size;
             scroll_cache.page_size = None;
             scroll_cache.split_points.clear();

--- a/egui_commonmark_backend/src/pulldown.rs
+++ b/egui_commonmark_backend/src/pulldown.rs
@@ -8,6 +8,10 @@ pub struct ScrollableCache {
     pub available_size: Vec2,
     pub page_size: Option<Vec2>,
     pub split_points: Vec<(usize, Pos2, Pos2)>,
+    pub parsed_events: Vec<(pulldown_cmark::Event<'static>, Range<usize>)>,
+    pub parsed_text_ptr: usize,
+    pub parsed_text_len: usize,
+    pub parser_options_bits: u32,
 }
 
 pub type EventIteratorItem<'e> = (usize, (pulldown_cmark::Event<'e>, Range<usize>));


### PR DESCRIPTION
Hello,

If you're interested, I made optimizations to the core rendering of commonmark and an example `streaming.rs` that shows the improvement. These are important when you want to deal with larger texts, or want to support frequent re-rendering. The example does both.

The main use-case in mind I had with these is to allow fast rendering of streamed LLM output.

**Disclosure**: The optimizations were done autonomously by an AI agent and I did not review them in detail. On a high-level, they seem okay to me.

In a testing environment, I've set up a harness that made screenshots via `egui_kittest` and made sure they render in the same way after optimizations. The tested screenshotted example included all aspects of markdown: headers, text styling, code examples, tables etc.

# Benchmarks

Before optimizations:

```
$ cargo run --package egui_commonmark --example streaming --release > original.txt
$ awk 'NR==1 || ((NR-1)%1000)==0 { printf "%s\n", $0 }' "original.txt" 

frame 0: chars: 8671, cache regen: 2.228 ms
frame 1000: chars: 108671, cache regen: 1.099 ms
frame 2000: chars: 208671, cache regen: 2.314 ms
frame 3000: chars: 308671, cache regen: 3.542 ms
frame 4000: chars: 408671, cache regen: 4.684 ms
frame 5000: chars: 508671, cache regen: 5.737 ms
frame 6000: chars: 608671, cache regen: 7.898 ms
frame 7000: chars: 708671, cache regen: 7.839 ms
frame 8000: chars: 808671, cache regen: 9.669 ms
frame 9000: chars: 908671, cache regen: 10.798 ms
frame 10000: chars: 1008671, cache regen: 13.426 ms

$ awk '{ if (match($0, /cache regen: ([0-9.]+) ms/, m)) { n++; v[n]=m[1]+0 } } END { if (n==0) { print "no samples"; exit 1 } asort(v); p50_i=int((n-1)*0.50)+1; p99_i=int((n-1)*0.99)+1; printf "count=%d\nmin=%.3f\np50=%.3f\np99=%.3f\nmax=%.3f\n", n, v[1], v[p50_i], v[p99_i], v[n]; }' "original.txt"

count=10038
min=0.161
p50=6.112
p99=13.573
max=19.483
```

After optimizations:

```
$ cargo run --package egui_commonmark --example streaming --release > opt.txt
$ awk 'NR==1 || ((NR-1)%1000)==0 { printf "%s\n", $0 }' "opt.txt" 

frame 0: chars: 8671, cache regen: 2.407 ms
frame 1000: chars: 108671, cache regen: 0.170 ms
frame 2000: chars: 208671, cache regen: 0.196 ms
frame 3000: chars: 308671, cache regen: 0.293 ms
frame 4000: chars: 408671, cache regen: 0.289 ms
frame 5000: chars: 508671, cache regen: 0.347 ms
frame 6000: chars: 608671, cache regen: 0.358 ms
frame 7000: chars: 708671, cache regen: 0.518 ms
frame 8000: chars: 808671, cache regen: 0.565 ms
frame 9000: chars: 908671, cache regen: 0.675 ms
frame 10000: chars: 1008671, cache regen: 0.684 ms

$  awk '{ if (match($0, /cache regen: ([0-9.]+) ms/, m)) { n++; v[n]=m[1]+0 } } END { if (n==0) { print "no samples"; exit 1 } asort(v); p50_i=int((n-1)*0.50)+1; p99_i=int((n-1)*0.99)+1; printf "count=%d\nmin=%.3f\np50=%.3f\np99=%.3f\nmax=%.3f\n", n, v[1], v[p50_i], v[p99_i], v[n]; }' "opt.txt"

count=10685
min=0.048
p50=0.369
p99=0.836
max=2.503
```

