### PR TITLE
Fix show_scrollable to support seamless scrolling of large documents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "document-features",
  "eframe",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "data-url",
  "egui",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_macros"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "document-features",
  "egui",

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -1,0 +1,85 @@
+//! Make sure to run this example from the repo directory and not the example
+//! directory. Run with:
+//! `cargo r --example scroll --features better_syntax_highlighting,svg`
+//! Add `light` or `dark` to set the theme.
+
+use eframe::egui;
+use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
+
+struct App {
+    cache: CommonMarkCache,
+    content: String,
+}
+
+impl eframe::App for App {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ui, |ui| {
+            CommonMarkViewer::new()
+                .max_image_width(Some(512))
+                .enable_scroll_to_heading(true)
+                .show_scrollable("scroll_example", ui, &mut self.cache, &self.content);
+        });
+    }
+}
+
+fn main() -> eframe::Result {
+    let mut args = std::env::args();
+    args.next();
+
+    let content = build_document();
+    eprintln!("Document size: {} bytes", content.len());
+
+    eframe::run_native(
+        "Markdown scroll example",
+        eframe::NativeOptions::default(),
+        Box::new(move |cc| {
+            if let Some(theme) = args.next() {
+                if theme == "light" {
+                    cc.egui_ctx.set_theme(egui::Theme::Light);
+                } else if theme == "dark" {
+                    cc.egui_ctx.set_theme(egui::Theme::Dark);
+                }
+            }
+            Ok(Box::new(App {
+                cache: CommonMarkCache::default(),
+                content,
+            }))
+        }),
+    )
+}
+
+fn build_document() -> String {
+    let mut text = String::from(
+        "# Markdown Scroll Example\n\
+         \n\
+         Jump to: [Section 500](#section-500)\n\
+         \n\
+         This document demonstrates `show_scrollable`: only the visible slice is \
+         rendered each frame, so scrolling stays fast regardless of document length. \
+         The TOC link above jumps to section 500, far outside the initial viewport, \
+         to demonstrate that heading navigation works across the full document.\n\
+         \n",
+    );
+
+    for i in 1..=1024_usize {
+        let id = if i == 500 { " {#section-500}" } else { "" };
+        text += &format!(
+            "\n## Section {i}{id}\n\
+             \n\
+             This is section {i}. Each section contains a short code block and an image.\n\
+             \n\
+             ```rs\n\
+             let mut vec = Vec::new();\n\
+             vec.push({i});\n\
+             ```\n\
+             \n\
+             * Make a sandwich\n\
+             * Bake a cake\n\
+             * Conquer the world\n\
+             \n\
+             ![Ferris the Rust mascot](egui_commonmark/examples/cuddlyferris.png)\n\
+             \n"
+        );
+    }
+    text
+}

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -371,7 +371,13 @@ impl List {
                 bullet_point(ui);
             }
         } else {
-            unreachable!();
+            // The list stack is empty.  This can happen in the viewport-cache
+            // path when the visible slice starts with a Start(Item) event whose
+            // enclosing Start(List) fell just outside the rendered window.
+            // Synthesise a top-level unordered list level so the item renders
+            // reasonably rather than panicking.
+            self.start_level_without_number();
+            bullet_point(ui);
         }
 
         ui.add_space(4.0);

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -300,7 +300,6 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// [`ScrollArea`]: egui::ScrollArea
     /// [`show`]: crate::CommonMarkViewer::show
-    #[doc(hidden)] // Buggy in scenarios more complex than the example application
     #[cfg(feature = "pulldown_cmark")]
     pub fn show_scrollable(
         self,

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -390,6 +390,10 @@ impl CommonMarkViewerInternal {
                             self.line.should_not_start_newline_forced = false;
                         }
                     }
+
+                    // Mirror show()'s deferred flush so that clicking a #fragment link
+                    // while in the viewport path also triggers a scroll next frame.
+                    *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
                 });
             });
 

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -913,10 +913,10 @@ impl CommonMarkViewerInternal {
                 }
             }
             pulldown_cmark::TagEnd::Image => {
-                if let Some(image) = self.image.take() {
-                    if image.end(ui, options) < 1.0 {
-                        self.any_image_loading = true;
-                    }
+                if let Some(image) = self.image.take()
+                    && image.end(ui, options) < 1.0
+                {
+                    self.any_image_loading = true;
                 }
             }
             pulldown_cmark::TagEnd::HtmlBlock => {

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -84,6 +84,10 @@ pub struct CommonMarkViewerInternal {
     is_blockquote: bool,
     checkbox_events: Vec<CheckboxClickEvent>,
     deferred_scroll_to_heading: Option<String>,
+    /// Set during a full render if any image rendered at zero height (texture
+    /// still loading). When true, split points are discarded and the full render
+    /// repeats next frame until all images have stable heights.
+    any_image_loading: bool,
 }
 
 pub(crate) struct CheckboxClickEvent {
@@ -108,6 +112,7 @@ impl CommonMarkViewerInternal {
             is_blockquote: false,
             checkbox_events: Vec::new(),
             deferred_scroll_to_heading: None,
+            any_image_loading: false,
         }
     }
 }
@@ -137,6 +142,7 @@ impl CommonMarkViewerInternal {
         text: &str,
         split_points_id: Option<Id>,
     ) -> (egui::InnerResponse<()>, Vec<CheckboxClickEvent>) {
+        self.any_image_loading = false;
         let max_width = options.max_width(ui);
         let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
 
@@ -153,10 +159,56 @@ impl CommonMarkViewerInternal {
             .enumerate()
             .peekable();
 
+            // Screen-space y of the content origin. Subtracting this from any
+            // cursor position gives virtual (content-relative) y comparable to
+            // viewport.min/max.y from show_viewport.
+            let content_origin_y = ui.next_widget_position().y;
+
+            // Cursor at the visual top of the current block, captured at
+            // Start(Block) so that vstart reflects the block top, not its bottom.
+            let mut block_start_position: Option<Pos2> = None;
+
             while let Some((index, (e, src_span))) = events.next() {
                 let start_position = ui.next_widget_position();
-                let is_element_end = matches!(e, pulldown_cmark::Event::End(_));
-                let should_add_split_point = self.list.is_inside_a_list() && is_element_end;
+
+                let is_safe_block_start = !self.list.is_inside_a_list()
+                    && matches!(
+                        e,
+                        pulldown_cmark::Event::Start(
+                            pulldown_cmark::Tag::Paragraph
+                                | pulldown_cmark::Tag::Heading { .. }
+                                | pulldown_cmark::Tag::CodeBlock(_)
+                        )
+                    );
+                if is_safe_block_start {
+                    block_start_position = Some(start_position);
+                }
+
+                // Record virtual y for each named heading so the viewport path
+                // can jump to headings that are outside the rendered slice.
+                if let (
+                    Some(sid),
+                    pulldown_cmark::Event::Start(pulldown_cmark::Tag::Heading {
+                        id: Some(id), ..
+                    }),
+                ) = (split_points_id, &e)
+                {
+                    scroll_cache(cache, &sid)
+                        .heading_y_positions
+                        .insert(id.to_string(), ui.cursor().min.y - content_origin_y);
+                }
+
+                // Only record split points at clean, top-level block boundaries
+                // where the renderer has no pending state and can restart safely.
+                let is_safe_block_end = !self.list.is_inside_a_list()
+                    && matches!(
+                        e,
+                        pulldown_cmark::Event::End(
+                            pulldown_cmark::TagEnd::Paragraph
+                                | pulldown_cmark::TagEnd::Heading { .. }
+                                | pulldown_cmark::TagEnd::CodeBlock
+                        )
+                    );
 
                 if events.peek().is_none() {
                     self.line.should_end_newline_forced = false;
@@ -165,7 +217,7 @@ impl CommonMarkViewerInternal {
                 self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
 
                 if let Some(source_id) = split_points_id
-                    && should_add_split_point
+                    && is_safe_block_end
                 {
                     let scroll_cache = scroll_cache(cache, &source_id);
                     let end_position = ui.next_widget_position();
@@ -176,9 +228,12 @@ impl CommonMarkViewerInternal {
                         .any(|(i, _, _)| *i == index);
 
                     if !split_point_exists {
-                        scroll_cache
-                            .split_points
-                            .push((index, start_position, end_position));
+                        // Use block_start_position (Start event) not start_position
+                        // (cursor just before End) so that vstart is the block top.
+                        let raw_vstart = block_start_position.take().unwrap_or(start_position);
+                        let vstart = egui::pos2(raw_vstart.x, raw_vstart.y - content_origin_y);
+                        let vend = egui::pos2(end_position.x, end_position.y - content_origin_y);
+                        scroll_cache.split_points.push((index, vstart, vend));
                     }
                 }
 
@@ -191,8 +246,18 @@ impl CommonMarkViewerInternal {
             *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
 
             if let Some(source_id) = split_points_id {
-                scroll_cache(cache, &source_id).page_size =
-                    Some(ui.next_widget_position().to_vec2());
+                if self.any_image_loading {
+                    // Images are still loading — split points are unreliable.
+                    // Discard and leave page_size = None so the full render repeats
+                    // next frame (the image loader triggers the repaint automatically).
+                    let sc = scroll_cache(cache, &source_id);
+                    sc.split_points.clear();
+                    sc.heading_y_positions.clear();
+                } else {
+                    let final_y = ui.next_widget_position().y;
+                    scroll_cache(cache, &source_id).page_size =
+                        Some(egui::vec2(max_width, final_y - content_origin_y));
+                }
             }
         });
 
@@ -217,7 +282,6 @@ impl CommonMarkViewerInternal {
                 .show(ui, |ui| {
                     self.show(ui, cache, options, text, Some(source_id));
                 });
-            // Prevent repopulating points twice at startup
             scroll_cache(cache, &source_id).available_size = available_size;
             return;
         };
@@ -231,6 +295,23 @@ impl CommonMarkViewerInternal {
 
         let num_rows = events.len();
 
+        // Resolve any pending TOC scroll via the cached heading positions so that
+        // navigation works even when the target is outside the rendered slice.
+        let pending_scroll_y: Option<f32> = {
+            let slug_owned = cache.scroll_to_id_target().map(|s| s.to_owned());
+            if let Some(ref slug) = slug_owned {
+                let sc = scroll_cache(cache, &source_id);
+                if let Some(&y) = sc.heading_y_positions.get(slug) {
+                    cache.scroll_to_id_target_mut().take();
+                    Some(y)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+
         egui::ScrollArea::vertical()
             .id_salt(scroll_id)
             // Elements have different widths, so the scroll area cannot try to shrink to the
@@ -238,6 +319,17 @@ impl CommonMarkViewerInternal {
             // with different widths.
             .auto_shrink([false, true])
             .show_viewport(ui, |ui, viewport| {
+                if let Some(y) = pending_scroll_y {
+                    // heading_y_positions stores virtual y (content-relative, 0 = top).
+                    // Inside show_viewport, next_widget_position().y = screen_top − scroll.
+                    // scroll_to_rect with Align::TOP sets new_scroll = y. ✓
+                    let r = egui::Rect::from_min_size(
+                        egui::pos2(0.0, ui.next_widget_position().y + y),
+                        egui::Vec2::ZERO,
+                    );
+                    ui.scroll_to_rect(r, Some(egui::Align::TOP));
+                }
+
                 ui.set_height(page_size.y);
                 let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
 
@@ -246,41 +338,54 @@ impl CommonMarkViewerInternal {
                     ui.spacing_mut().item_spacing.x = 0.0;
                     let scroll_cache = scroll_cache(cache, &source_id);
 
-                    // finding the first element that's not in the viewport anymore
-                    let (first_event_index, _, first_end_position) = scroll_cache
+                    // Render one full viewport-height below the visible bottom so
+                    // that scrolling down never reveals a trailing blank region.
+                    let viewport_height = viewport.max.y - viewport.min.y;
+                    let render_below = viewport.max.y + viewport_height;
+
+                    let preceding_split = scroll_cache
                         .split_points
                         .iter()
-                        .filter(|(_, _, end_position)| end_position.y < viewport.min.y)
-                        .nth_back(1)
-                        .copied()
-                        .unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
+                        .rfind(|(_, _, vend)| vend.y < viewport.min.y)
+                        .copied();
 
-                    // finding the last element that's just outside the viewport
+                    let (_first_event_index, _, first_end_position) =
+                        preceding_split.unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
+
                     let last_event_index = scroll_cache
                         .split_points
                         .iter()
-                        .filter(|(_, start_position, _)| start_position.y > viewport.max.y)
-                        .nth(1)
+                        .find(|(_, vstart, _)| vstart.y > render_below)
                         .map(|(index, _, _)| *index)
                         .unwrap_or(num_rows);
 
-                    ui.allocate_space(first_end_position.to_vec2());
+                    // Allocate a full-width block for the off-screen content so
+                    // that the cursor lands at the correct x for the first visible block.
+                    let skip_height = first_end_position.y.max(0.0);
+                    ui.allocate_space(egui::vec2(max_width, skip_height));
 
-                    // only rendering the elements that are inside the viewport
+                    // When a preceding split was found, its End(Block) is already
+                    // accounted for in skip_height — re-processing it would add a
+                    // duplicate newline. Start from the next event instead.
+                    let (skip_count, take_count) = if let Some((idx, _, _)) = preceding_split {
+                        self.line.should_not_start_newline_forced = false;
+                        (idx + 1, last_event_index - idx)
+                    } else {
+                        (0, last_event_index)
+                    };
+
                     let mut events = events
                         .into_iter()
                         .enumerate()
-                        .skip(first_event_index)
-                        .take(last_event_index - first_event_index)
+                        .skip(skip_count)
+                        .take(take_count)
                         .peekable();
 
                     while let Some((i, (e, src_span))) = events.next() {
                         if events.peek().is_none() {
                             self.line.should_end_newline_forced = false;
                         }
-
                         self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
-
                         if i == 0 {
                             self.line.should_not_start_newline_forced = false;
                         }
@@ -288,12 +393,22 @@ impl CommonMarkViewerInternal {
                 });
             });
 
-        // Forcing full re-render to repopulate split points for the new size
+        // If any image in this render reported zero height, split points are stale.
+        // Discard them so the next frame falls back to a full render.
+        if self.any_image_loading {
+            let sc = scroll_cache(cache, &source_id);
+            sc.page_size = None;
+            sc.split_points.clear();
+            sc.heading_y_positions.clear();
+        }
+
+        // Invalidate the cache when the available size changes (e.g. window resize).
         let scroll_cache = scroll_cache(cache, &source_id);
         if available_size != scroll_cache.available_size {
             scroll_cache.available_size = available_size;
             scroll_cache.page_size = None;
             scroll_cache.split_points.clear();
+            scroll_cache.heading_y_positions.clear();
         }
     }
 
@@ -795,7 +910,9 @@ impl CommonMarkViewerInternal {
             }
             pulldown_cmark::TagEnd::Image => {
                 if let Some(image) = self.image.take() {
-                    image.end(ui, options);
+                    if image.end(ui, options) < 1.0 {
+                        self.any_image_loading = true;
+                    }
                 }
             }
             pulldown_cmark::TagEnd::HtmlBlock => {

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -336,43 +336,39 @@ impl CommonMarkViewerInternal {
                 let max_width = options.max_width(ui);
                 ui.allocate_ui_with_layout(egui::vec2(max_width, 0.0), layout, |ui| {
                     ui.spacing_mut().item_spacing.x = 0.0;
-                    let scroll_cache = scroll_cache(cache, &source_id);
 
-                    // Render one full viewport-height below the visible bottom so
-                    // that scrolling down never reveals a trailing blank region.
+                    // Compute the slice parameters and release the scroll_cache borrow
+                    // before the push_id closure so that `cache` is freely accessible
+                    // inside it.
                     let viewport_height = viewport.max.y - viewport.min.y;
                     let render_below = viewport.max.y + viewport_height;
-
-                    let preceding_split = scroll_cache
-                        .split_points
-                        .iter()
-                        .rfind(|(_, _, vend)| vend.y < viewport.min.y)
-                        .copied();
-
-                    let (_first_event_index, _, first_end_position) =
-                        preceding_split.unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
-
-                    let last_event_index = scroll_cache
-                        .split_points
-                        .iter()
-                        .find(|(_, vstart, _)| vstart.y > render_below)
-                        .map(|(index, _, _)| *index)
-                        .unwrap_or(num_rows);
-
-                    // Allocate a full-width block for the off-screen content so
-                    // that the cursor lands at the correct x for the first visible block.
-                    let skip_height = first_end_position.y.max(0.0);
-                    ui.allocate_space(egui::vec2(max_width, skip_height));
-
-                    // When a preceding split was found, its End(Block) is already
-                    // accounted for in skip_height — re-processing it would add a
-                    // duplicate newline. Start from the next event instead.
-                    let (skip_count, take_count) = if let Some((idx, _, _)) = preceding_split {
-                        self.line.should_not_start_newline_forced = false;
-                        (idx + 1, last_event_index - idx)
-                    } else {
-                        (0, last_event_index)
-                    };
+                    let (skip_height, skip_count, take_count) = {
+                        let scroll_cache = scroll_cache(cache, &source_id);
+                        let preceding_split = scroll_cache
+                            .split_points
+                            .iter()
+                            .rfind(|(_, _, vend)| vend.y < viewport.min.y)
+                            .copied();
+                        let (_first_event_index, _, first_end_position) =
+                            preceding_split.unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
+                        let last_event_index = scroll_cache
+                            .split_points
+                            .iter()
+                            .find(|(_, vstart, _)| vstart.y > render_below)
+                            .map(|(index, _, _)| *index)
+                            .unwrap_or(num_rows);
+                        let skip_height = first_end_position.y.max(0.0);
+                        // When a preceding split was found, its End(Block) is already
+                        // accounted for in skip_height — re-processing it would add a
+                        // duplicate newline. Start from the next event instead.
+                        let (skip_count, take_count) = if let Some((idx, _, _)) = preceding_split {
+                            self.line.should_not_start_newline_forced = false;
+                            (idx + 1, last_event_index - idx)
+                        } else {
+                            (0, last_event_index)
+                        };
+                        (skip_height, skip_count, take_count)
+                    }; // scroll_cache borrow released here
 
                     let mut events = events
                         .into_iter()
@@ -381,19 +377,48 @@ impl CommonMarkViewerInternal {
                         .take(take_count)
                         .peekable();
 
-                    while let Some((i, (e, src_span))) = events.next() {
-                        if events.peek().is_none() {
-                            self.line.should_end_newline_forced = false;
-                        }
-                        self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
-                        if i == 0 {
-                            self.line.should_not_start_newline_forced = false;
-                        }
-                    }
+                    // Give the viewport render a distinct widget parent_id namespace
+                    // from the full-render path.  egui's warn_if_rect_changes_id check
+                    // only fires when the same screen rect has different widget IDs
+                    // *and* at least one widget shares a parent_id between consecutive
+                    // frames.  Using a different salt here vs the full-render path makes
+                    // the parent_id comparison always fail on the transition frame,
+                    // eliminating the spurious one-frame red outlines on image load and
+                    // window resize.
+                    //
+                    // IMPORTANT: push_id must be called BEFORE allocate_space so that
+                    // the cursor is still at (0, 0) — the left edge of a full-width row.
+                    // Calling it after allocate_space leaves the cursor at (max_width, …)
+                    // (right edge), making available_rect_before_wrap() return a
+                    // near-zero width and collapsing all content to a 1-pixel stripe.
+                    ui.push_id("__cm_viewport", |ui| {
+                        // Skip over off-screen content by reserving its vertical space.
+                        // Full width is essential: a narrower allocation would leave
+                        // the cursor mid-row, misaligning the first visible block.
+                        ui.allocate_space(egui::vec2(max_width, skip_height));
 
-                    // Mirror show()'s deferred flush so that clicking a #fragment link
-                    // while in the viewport path also triggers a scroll next frame.
-                    *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
+                        while let Some((i, (e, src_span))) = events.next() {
+                            if events.peek().is_none() {
+                                self.line.should_end_newline_forced = false;
+                            }
+                            self.process_event(
+                                ui,
+                                &mut events,
+                                e,
+                                src_span,
+                                cache,
+                                options,
+                                max_width,
+                            );
+                            if i == 0 {
+                                self.line.should_not_start_newline_forced = false;
+                            }
+                        }
+
+                        // Mirror show()'s deferred flush so that clicking a #fragment
+                        // link while in the viewport path triggers a scroll next frame.
+                        *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
+                    });
                 });
             });
 

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -382,20 +382,34 @@ impl CommonMarkViewerInternal {
                         .peekable();
 
                     // Give the viewport render a distinct widget parent_id namespace
-                    // from the full-render path.  egui's warn_if_rect_changes_id check
-                    // only fires when the same screen rect has different widget IDs
-                    // *and* at least one widget shares a parent_id between consecutive
-                    // frames.  Using a different salt here vs the full-render path makes
-                    // the parent_id comparison always fail on the transition frame,
-                    // eliminating the spurious one-frame red outlines on image load and
-                    // window resize.
+                    // so that egui's warn_if_rect_changes_id check never fires.
+                    //
+                    // The check fires when the same screen rect has different widget
+                    // IDs *and* at least one widget shares a parent_id between
+                    // consecutive frames.  Widget IDs within this push_id scope are
+                    // counter-based (sequential from 0 each frame).  The counter
+                    // resets at the start of each rendered slice, so when skip_count
+                    // advances by 1 (viewport crosses a split-point boundary), every
+                    // widget in the visible overlap shifts its ID by 1 — same rect,
+                    // same parent_id, different ID → warning fires.
+                    //
+                    // Fix: bake skip_count into the push_id salt.  Consecutive frames
+                    // with different skip_count values get different parent_ids, so the
+                    // parent_id match condition is never met.  When skip_count is
+                    // stable (viewport moves within a split-point interval), the same
+                    // slice renders with identical counter values → same IDs → no
+                    // warning then either.
+                    //
+                    // The salt tuple also differs from the full-render path's implicit
+                    // parent (no push_id), so the transition-frame guard from the
+                    // full→viewport fix remains intact.
                     //
                     // IMPORTANT: push_id must be called BEFORE allocate_space so that
-                    // the cursor is still at (0, 0) — the left edge of a full-width row.
-                    // Calling it after allocate_space leaves the cursor at (max_width, …)
-                    // (right edge), making available_rect_before_wrap() return a
-                    // near-zero width and collapsing all content to a 1-pixel stripe.
-                    ui.push_id("__cm_viewport", |ui| {
+                    // the cursor is still at (0, 0) — the left edge of a full-width
+                    // row.  Calling it after allocate_space leaves the cursor at
+                    // (max_width, …) (right edge), making available_rect_before_wrap()
+                    // return near-zero width and collapsing all content to a thin strip.
+                    ui.push_id(("__cm_viewport", skip_count), |ui| {
                         // Skip over off-screen content by reserving its vertical space.
                         // Full width is essential: a narrower allocation would leave
                         // the cursor mid-row, misaligning the first visible block.

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -363,7 +363,11 @@ impl CommonMarkViewerInternal {
                         // duplicate newline. Start from the next event instead.
                         let (skip_count, take_count) = if let Some((idx, _, _)) = preceding_split {
                             self.line.should_not_start_newline_forced = false;
-                            (idx + 1, last_event_index - idx)
+                            // last_event_index should always be >= idx because
+                            // split-points are ordered, but guard against stale
+                            // cache or tiny documents producing an underflow.
+                            let take = last_event_index.saturating_sub(idx);
+                            (idx + 1, take)
                         } else {
                             (0, last_event_index)
                         };

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -263,20 +263,35 @@ impl Image {
         }
     }
 
-    pub fn end(self, ui: &mut Ui, options: &CommonMarkOptions) {
+    /// Returns the rendered height in points, or `0.0` if the texture is still
+    /// loading. The caller uses this to detect whether split-point heights can
+    /// be trusted.
+    pub fn end(self, ui: &mut Ui, options: &CommonMarkOptions) -> f32 {
+        let Self { uri, alt_text } = self;
         let response = ui.add(
-            egui::Image::from_uri(&self.uri)
+            egui::Image::from_uri(&uri)
                 .fit_to_original_size(1.0)
                 .max_width(options.max_width(ui)),
         );
-
-        if !self.alt_text.is_empty() && options.show_alt_text_on_hover {
+        let height = response.rect.height();
+        if !alt_text.is_empty() && options.show_alt_text_on_hover {
             response.on_hover_ui_at_pointer(|ui| {
-                for alt in self.alt_text {
+                for alt in alt_text {
                     ui.label(alt);
                 }
             });
         }
+        // egui's 24×24 placeholder means height ≥ 1.0 even while Pending, so
+        // query the load state directly rather than relying on height alone.
+        let is_pending = matches!(
+            ui.ctx().try_load_texture(
+                &uri,
+                egui::TextureOptions::default(),
+                egui::load::SizeHint::default(),
+            ),
+            Ok(egui::load::TexturePoll::Pending { .. })
+        );
+        if is_pending { 0.0 } else { height }
     }
 }
 

--- a/egui_commonmark_backend/src/pulldown.rs
+++ b/egui_commonmark_backend/src/pulldown.rs
@@ -1,6 +1,7 @@
 use crate::alerts::*;
 use egui::{Pos2, Vec2};
 use pulldown_cmark::Options;
+use std::collections::HashMap;
 use std::ops::Range;
 
 #[derive(Default, Debug)]
@@ -8,6 +9,10 @@ pub struct ScrollableCache {
     pub available_size: Vec2,
     pub page_size: Option<Vec2>,
     pub split_points: Vec<(usize, Pos2, Pos2)>,
+    /// Heading slug → virtual y (content-relative; 0 = document top).
+    /// Populated during the full render; used by the viewport path to
+    /// scroll to headings outside the currently rendered slice.
+    pub heading_y_positions: HashMap<String, f32>,
 }
 
 pub type EventIteratorItem<'e> = (usize, (pulldown_cmark::Event<'e>, Range<usize>));


### PR DESCRIPTION
The `show_scrollable` function was introduced in 36d2527 to allow for "much larger markdown files to be loaded without any performance penalty". Unfortunately, as of v0.24.0, the `show_scrollable` function is still avowedly buggy and documentation has been hidden for this reason.

The current PR is to fix this issue by correcting the virtualisation logic. It also reinstates the `scroll` example that was removed in b2ff158 and gives it some compatibility upgrades as well as enhancements such as building the document up front instead of on each UI refresh. It demonstrates image scrolling, which was previously problematic, and contains a sample link to demonstrate that heading navigation works correctly to locations well outside the initial viewport.

A follow-up PR in preparation will add search match highlighting (excluding inside code blocks), a `viewport_cache(bool) ` builder on `CommonMarkViewer` backed by `use_viewport_cache` in `CommonMarkOptions`, and further enhancements to the `scroll` example, namely a demonstration of keyboard scrolling and the option to run the example without the viewport caching in order to highlight the performance difference offered by the change. It will also add 14 small unit tests of the most complex interval-computation logic.