### PR TITLE
Add search-match highlighting and further large markdown enhancements

### DIFF
--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -1,0 +1,85 @@
+//! Make sure to run this example from the repo directory and not the example
+//! directory. Run with:
+//! `cargo r --example scroll --features better_syntax_highlighting,svg`
+//! Add `light` or `dark` to set the theme.
+
+use eframe::egui;
+use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
+
+struct App {
+    cache: CommonMarkCache,
+    content: String,
+}
+
+impl eframe::App for App {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ui, |ui| {
+            CommonMarkViewer::new()
+                .max_image_width(Some(512))
+                .enable_scroll_to_heading(true)
+                .show_scrollable("scroll_example", ui, &mut self.cache, &self.content);
+        });
+    }
+}
+
+fn main() -> eframe::Result {
+    let mut args = std::env::args();
+    args.next();
+
+    let content = build_document();
+    eprintln!("Document size: {} bytes", content.len());
+
+    eframe::run_native(
+        "Markdown scroll example",
+        eframe::NativeOptions::default(),
+        Box::new(move |cc| {
+            if let Some(theme) = args.next() {
+                if theme == "light" {
+                    cc.egui_ctx.set_theme(egui::Theme::Light);
+                } else if theme == "dark" {
+                    cc.egui_ctx.set_theme(egui::Theme::Dark);
+                }
+            }
+            Ok(Box::new(App {
+                cache: CommonMarkCache::default(),
+                content,
+            }))
+        }),
+    )
+}
+
+fn build_document() -> String {
+    let mut text = String::from(
+        "# Markdown Scroll Example\n\
+         \n\
+         Jump to: [Section 500](#section-500)\n\
+         \n\
+         This document demonstrates `show_scrollable`: only the visible slice is \
+         rendered each frame, so scrolling stays fast regardless of document length. \
+         The TOC link above jumps to section 500, far outside the initial viewport, \
+         to demonstrate that heading navigation works across the full document.\n\
+         \n",
+    );
+
+    for i in 1..=1024_usize {
+        let id = if i == 500 { " {#section-500}" } else { "" };
+        text += &format!(
+            "\n## Section {i}{id}\n\
+             \n\
+             This is section {i}. Each section contains a short code block and an image.\n\
+             \n\
+             ```rs\n\
+             let mut vec = Vec::new();\n\
+             vec.push({i});\n\
+             ```\n\
+             \n\
+             * Make a sandwich\n\
+             * Bake a cake\n\
+             * Conquer the world\n\
+             \n\
+             ![Ferris the Rust mascot](egui_commonmark/examples/cuddlyferris.png)\n\
+             \n"
+        );
+    }
+    text
+}

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -19,17 +19,7 @@ impl eframe::App for App {
         ui.set_min_height(512.0);
 
         egui::CentralPanel::default().show(ui, |ui| {
-            // Style the scroll bar to make the thumb position clearly visible.
-            {
-                let scroll = &mut ui.style_mut().spacing.scroll;
-                scroll.floating = true;
-                scroll.floating_width = 7.0;
-                scroll.content_margin = egui::Margin::same(10);
-                scroll.bar_width = 10.0;
-                scroll.dormant_handle_opacity = 0.40;
-                scroll.interact_handle_opacity = 0.55;
-                scroll.active_handle_opacity = 0.80;
-            }
+            ui.style_mut().spacing.scroll = egui::style::ScrollStyle::thin();
 
             let (
                 scroll_line_up,
@@ -129,45 +119,27 @@ fn build_document() -> String {
          \n",
     );
 
-    let repeating = "\n\
-        This section will be repeated.\n\
-        \n\
-        ```rs\n\
-        let mut vec = Vec::new();\n\
-        vec.push(5);\n\
-        ```\n\
-        \n\
-        # Plans\n\
-        * Make a sandwich\n\
-        * Bake a cake\n\
-        * Conquer the world\n\
-        \n\
-        ![Ferris the Rust mascot](egui_commonmark/examples/cuddlyferris.png)\n\
-        \n";
-
-    // Insert a named anchor at a predictable location for the TOC link demo.
-    let anchor_section = "\n\
-        This section will be repeated.\n\
-        \n\
-        ```rs\n\
-        let mut vec = Vec::new();\n\
-        vec.push(5);\n\
-        ```\n\
-        \n\
-        # Plans {#section-500}\n\
-        * Make a sandwich\n\
-        * Bake a cake\n\
-        * Conquer the world\n\
-        \n\
-        ![Ferris the Rust mascot](egui_commonmark/examples/cuddlyferris.png)\n\
-        \n";
-
     for i in 1..=1024_usize {
-        if i == 500 {
-            text += anchor_section;
-        } else {
-            text += repeating;
-        }
+        let id = if i == 500 { " {#section-500}" } else { "" };
+        text += &format!(
+            r#"
+## Section {i}{id}
+
+This is section {i}. Each section contains a short code block and an image.
+
+```rs
+let mut vec = Vec::new();
+vec.push({i});
+```
+* Make a sandwich
+* Bake a cake
+* Conquer the world
+
+![Ferris the Rust mascot](egui_commonmark/examples/cuddlyferris.png)
+
+"#
+        );
     }
+
     text
 }

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -1,7 +1,9 @@
 //! Make sure to run this example from the repo directory and not the example
 //! directory. Run with:
-//! `cargo r --example scroll --features better_syntax_highlighting,svg`
-//! Add `light` or `dark` to set the theme.
+//! `cargo r --example scroll --features better_syntax_highlighting,svg [light|dark]`
+//! Run with CACHE=false to disable viewport caching for comparison.
+
+use std::env;
 
 use eframe::egui;
 use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
@@ -9,22 +11,83 @@ use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
 struct App {
     cache: CommonMarkCache,
     content: String,
+    viewport_cache: bool,
 }
 
 impl eframe::App for App {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        ui.set_min_height(512.0);
+
         egui::CentralPanel::default().show(ui, |ui| {
+            // Style the scroll bar to make the thumb position clearly visible.
+            {
+                let scroll = &mut ui.style_mut().spacing.scroll;
+                scroll.floating = true;
+                scroll.floating_width = 7.0;
+                scroll.content_margin = egui::Margin::same(10);
+                scroll.bar_width = 10.0;
+                scroll.dormant_handle_opacity = 0.40;
+                scroll.interact_handle_opacity = 0.55;
+                scroll.active_handle_opacity = 0.80;
+            }
+
+            let (
+                scroll_line_up,
+                scroll_line_down,
+                scroll_page_up,
+                scroll_page_down,
+                scroll_doc_top,
+                scroll_doc_bottom,
+            ) = ui.ctx().input(|i| {
+                use egui::Key;
+                (
+                    !i.modifiers.command && i.key_pressed(Key::ArrowUp),
+                    !i.modifiers.command && i.key_pressed(Key::ArrowDown),
+                    i.key_pressed(Key::PageUp),
+                    i.key_pressed(Key::PageDown),
+                    i.key_pressed(Key::Home)
+                        || (i.modifiers.command && i.key_pressed(Key::ArrowUp)),
+                    i.key_pressed(Key::End)
+                        || (i.modifiers.command && i.key_pressed(Key::ArrowDown)),
+                )
+            });
+
+            // Only act on scroll keys when no text field has focus.
+            if !ui.ctx().egui_wants_keyboard_input() {
+                let line_h = ui.text_style_height(&egui::TextStyle::Body);
+                let page_h = ui.available_height();
+                if scroll_line_up {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, line_h));
+                } else if scroll_line_down {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, -line_h));
+                } else if scroll_page_up {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, page_h));
+                } else if scroll_page_down {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, -page_h));
+                } else if scroll_doc_top {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, f32::MAX / 2.0));
+                } else if scroll_doc_bottom {
+                    self.cache
+                        .set_scroll_delta(egui::vec2(0.0, -f32::MAX / 2.0));
+                }
+            }
+
             CommonMarkViewer::new()
                 .max_image_width(Some(512))
                 .enable_scroll_to_heading(true)
+                .viewport_cache(self.viewport_cache)
                 .show_scrollable("scroll_example", ui, &mut self.cache, &self.content);
         });
     }
 }
 
 fn main() -> eframe::Result {
-    let mut args = std::env::args();
+    let mut args = env::args();
     args.next();
+
+    let viewport_cache = env::var("CACHE")
+        .map(|v| v.to_lowercase() != "false" && v != "0")
+        .unwrap_or(true);
 
     let content = build_document();
     eprintln!("Document size: {} bytes", content.len());
@@ -43,6 +106,7 @@ fn main() -> eframe::Result {
             Ok(Box::new(App {
                 cache: CommonMarkCache::default(),
                 content,
+                viewport_cache,
             }))
         }),
     )
@@ -54,32 +118,56 @@ fn build_document() -> String {
          \n\
          Jump to: [Section 500](#section-500)\n\
          \n\
-         This document demonstrates `show_scrollable`: only the visible slice is \
-         rendered each frame, so scrolling stays fast regardless of document length. \
-         The TOC link above jumps to section 500, far outside the initial viewport, \
-         to demonstrate that heading navigation works across the full document.\n\
+         This document demonstrates `show_scrollable` with `viewport_cache(true)`: \
+         only the visible slice is rendered each frame, so scrolling stays fast \
+         regardless of document length. Run with `CACHE=false` to compare against \
+         the full-document render path.\n\
+         \n\
+         Keyboard shortcuts: Up/Down arrows scroll one line; Page Up/Down scroll \
+         one page; Home/End (Fn+Left/Right or Cmd+Up/Down on macOS) jump to \
+         document top or bottom.\n\
          \n",
     );
 
+    let repeating = "\n\
+        This section will be repeated.\n\
+        \n\
+        ```rs\n\
+        let mut vec = Vec::new();\n\
+        vec.push(5);\n\
+        ```\n\
+        \n\
+        # Plans\n\
+        * Make a sandwich\n\
+        * Bake a cake\n\
+        * Conquer the world\n\
+        \n\
+        ![Ferris the Rust mascot](egui_commonmark/examples/cuddlyferris.png)\n\
+        \n";
+
+    // Insert a named anchor at a predictable location for the TOC link demo.
+    let anchor_section = "\n\
+        This section will be repeated.\n\
+        \n\
+        ```rs\n\
+        let mut vec = Vec::new();\n\
+        vec.push(5);\n\
+        ```\n\
+        \n\
+        # Plans {#section-500}\n\
+        * Make a sandwich\n\
+        * Bake a cake\n\
+        * Conquer the world\n\
+        \n\
+        ![Ferris the Rust mascot](egui_commonmark/examples/cuddlyferris.png)\n\
+        \n";
+
     for i in 1..=1024_usize {
-        let id = if i == 500 { " {#section-500}" } else { "" };
-        text += &format!(
-            "\n## Section {i}{id}\n\
-             \n\
-             This is section {i}. Each section contains a short code block and an image.\n\
-             \n\
-             ```rs\n\
-             let mut vec = Vec::new();\n\
-             vec.push({i});\n\
-             ```\n\
-             \n\
-             * Make a sandwich\n\
-             * Bake a cake\n\
-             * Conquer the world\n\
-             \n\
-             ![Ferris the Rust mascot](egui_commonmark/examples/cuddlyferris.png)\n\
-             \n"
-        );
+        if i == 500 {
+            text += anchor_section;
+        } else {
+            text += repeating;
+        }
     }
     text
 }

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -1,82 +1,295 @@
 //! Demonstrates search-match highlighting with default colors.
 //!
+//! Typing in the search bar highlights every match. Prev/Next step through
+//! matches and scroll the document to the heading section containing each one.
+//!
 //! Run with:
 //! `cargo r --example search [light|dark]`
 
+use std::collections::HashMap;
+
 use eframe::egui;
 use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
+use pulldown_cmark::{Event, Options, Parser, Tag};
 
-const MARKDOWN: &str = "\
-# Search Highlighting
+const MARKDOWN: &str = r#"# Search Highlighting
 
 Type text in the search bar above to highlight every occurrence in this document.
 Use **Prev** and **Next** to step through matches.
 
-## Rust
+Suggestion: try a search string like "MIT" to demonstrate scrolling to the matches.
 
-Rust is a systems programming language focused on safety, speed, and concurrency.
-Rust achieves memory safety without a garbage collector.
+---
 
-## Why Rust?
+# A commonmark viewer for [egui](https://github.com/emilk/egui)
 
-Many developers choose Rust for its performance characteristics. The Rust compiler
-catches entire classes of bugs at compile time. Rust's ownership model ensures that
-data races are impossible.
+While this crate's main focus is commonmark, it also supports a subset of
+Github's markdown syntax: tables, strikethrough, tasklists and footnotes.
 
-## Getting Started with Rust
+## Features
 
-Install Rust via `rustup`. The Rust toolchain includes `cargo`, the build tool and
-package manager. Most Rust projects start with `cargo new`.
-";
+* `macros`: macros for compile time parsing of markdown
+* `better_syntax_highlighting`: Syntax highlighting inside code blocks with
+  [`syntect`](https://crates.io/crates/syntect)
+* `svg`: Support for viewing svg images
+* `fetch`: Images with urls will be downloaded and displayed
+* `embedded_image`: Load base64 image data urls from within markdown files
+
+
+## Examples
+
+For an easy intro check out the `hello_world` example. To see all the different
+features egui_commonmark has to offer check out the `book` example.
+
+## FAQ
+
+### URL is not displayed when hovering over a link
+
+By default egui does not show urls when you hover hyperlinks. To enable it,
+you can do the following before calling any ui related functions:
+
+```rust
+ui.style_mut().url_in_tooltip = true;
+```
+
+## MSRV Policy
+
+This crate uses the same MSRV as the latest released egui version.
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+"#;
+
+fn pc_opts() -> Options {
+    Options::ENABLE_TABLES
+        | Options::ENABLE_TASKLISTS
+        | Options::ENABLE_STRIKETHROUGH
+        | Options::ENABLE_FOOTNOTES
+        | Options::ENABLE_HEADING_ATTRIBUTES
+}
+
+/// Converts heading text to a URL-safe slug: lowercased, non-alphanumeric runs
+/// replaced by `-`.
+fn slugify(text: &str) -> String {
+    let mut slug = String::with_capacity(text.len());
+    let mut prev_sep = true;
+    for ch in text.chars() {
+        if ch.is_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            prev_sep = false;
+        } else if !prev_sep {
+            slug.push('-');
+            prev_sep = true;
+        }
+    }
+    if slug.ends_with('-') {
+        slug.pop();
+    }
+    slug
+}
+
+/// Parses an ATX heading line and returns `(level, plain_text)`, stripping any
+/// trailing `{…}` attribute block. Returns `None` for non-heading lines.
+#[allow(clippy::cast_possible_truncation)]
+fn parse_heading_line(line: &str) -> Option<(u8, &str)> {
+    let hashes = line.bytes().take_while(|&b| b == b'#').count();
+    if hashes == 0 || hashes > 6 {
+        return None;
+    }
+    let rest = line[hashes..].strip_prefix(' ')?;
+    let text = rest.trim_end();
+    if text.is_empty() {
+        return None;
+    }
+    let plain = text.rfind('{').map_or(text, |brace| {
+        let attr = text[brace..].trim_end();
+        if attr.ends_with('}') {
+            text[..brace].trim_end()
+        } else {
+            text
+        }
+    });
+    Some((hashes as u8, plain))
+}
+
+/// Returns the explicit `{#id}` from a heading line, if present.
+fn extract_heading_id(line: &str) -> Option<&str> {
+    let brace = line.rfind('{')?;
+    let attr = line[brace..].trim_end();
+    if attr.starts_with("{#") && attr.ends_with('}') {
+        Some(&attr[2..attr.len() - 1])
+    } else {
+        None
+    }
+}
+
+/// Scans `raw` markdown, injects `{#slug}` attributes into every heading that
+/// lacks one, and returns `(processed_content, slugs_in_order)`.
+///
+/// Uses pulldown-cmark as the heading oracle so that the injected IDs are
+/// consistent with what the renderer sees.
+fn inject_heading_ids(raw: &str) -> (String, Vec<String>) {
+    // Pass 1 — let pulldown-cmark locate the real heading starts.
+    let heading_starts: Vec<usize> = Parser::new_ext(raw, pc_opts())
+        .into_offset_iter()
+        .filter_map(|(event, span)| {
+            matches!(event, Event::Start(Tag::Heading { .. })).then_some(span.start)
+        })
+        .collect();
+
+    // Pass 2 — rebuild content, injecting `{#slug}` where needed.
+    let mut out = String::with_capacity(raw.len() + heading_starts.len() * 24);
+    let mut slugs: Vec<String> = Vec::new();
+    let mut slug_counts: HashMap<String, usize> = HashMap::new();
+    let mut pos = 0usize;
+
+    for line_start in heading_starts {
+        out.push_str(&raw[pos..line_start]);
+
+        let newline = raw[line_start..]
+            .find('\n')
+            .map_or(raw.len(), |p| line_start + p);
+        let line = &raw[line_start..newline];
+
+        if let Some((_level, plain_text)) = parse_heading_line(line) {
+            let (slug, injected) = extract_heading_id(line).map_or_else(
+                || {
+                    let base = slugify(plain_text);
+                    let n = slug_counts.entry(base.clone()).or_insert(0);
+                    let slug = if *n == 0 { base } else { format!("{base}-{n}") };
+                    *n += 1;
+                    let with_id = format!("{} {{#{slug}}}", line.trim_end());
+                    (slug, with_id)
+                },
+                |id| (id.to_string(), line.to_string()),
+            );
+            slugs.push(slug);
+            out.push_str(&injected);
+        } else {
+            // Setext or unrecognised heading — pass through unchanged.
+            out.push_str(line);
+        }
+
+        pos = if newline < raw.len() {
+            out.push('\n');
+            newline + 1
+        } else {
+            newline
+        };
+    }
+
+    out.push_str(&raw[pos..]);
+    (out, slugs)
+}
+
+/// Builds a `(byte_pos, slug)` list from the processed content and its slugs.
+/// The byte positions are content-relative (i.e. into the injected string).
+fn build_heading_positions(content: &str, slugs: &[String]) -> Vec<(usize, String)> {
+    let mut result = Vec::new();
+    let mut idx = 0;
+    for (event, span) in Parser::new_ext(content, pc_opts()).into_offset_iter() {
+        if matches!(event, Event::Start(Tag::Heading { .. })) {
+            if let Some(slug) = slugs.get(idx) {
+                result.push((span.start, slug.clone()));
+            }
+            idx += 1;
+        }
+    }
+    result
+}
+
+/// Appends the byte-start positions of all case-insensitive occurrences of
+/// `query` found within `text` to `out`. `span_start` is the offset of `text`
+/// within the full document.
+fn collect_matches(text: &str, span_start: usize, query: &str, qlen: usize, out: &mut Vec<usize>) {
+    let lower = text.to_lowercase();
+    let mut pos = 0;
+    while pos < lower.len() {
+        match lower[pos..].find(query) {
+            Some(rel) => {
+                out.push(span_start + pos + rel);
+                pos += rel + qlen;
+            }
+            None => break,
+        }
+    }
+}
 
 struct App {
+    /// Processed markdown with `{#slug}` IDs injected into every heading.
+    content: String,
     cache: CommonMarkCache,
     query: String,
-    /// Byte-range matches into MARKDOWN, in order.
-    matches: Vec<std::ops::Range<usize>>,
-    /// Index into `matches` for the active (focused) hit.
+    /// Byte start positions of matches within `content`, in document order.
+    matches: Vec<usize>,
+    /// Index of the active (focused) match.
     active: usize,
+    /// `(byte_pos, slug)` for each heading, used to scroll to the section
+    /// containing the active match.
+    heading_positions: Vec<(usize, String)>,
 }
 
 impl App {
     fn new() -> Self {
+        let (content, slugs) = inject_heading_ids(MARKDOWN);
+        let heading_positions = build_heading_positions(&content, &slugs);
         Self {
+            content,
             cache: CommonMarkCache::default(),
             query: String::new(),
             matches: Vec::new(),
             active: 0,
+            heading_positions,
         }
     }
 
-    /// Recompute all match ranges for the current query.
+    /// Rebuild `matches` by searching inside every text-bearing pulldown-cmark
+    /// event. This excludes the injected `{#slug}` attributes and link
+    /// destinations, which are not visible in the rendered output.
     fn update_matches(&mut self) {
         self.matches.clear();
+        self.active = 0;
         if self.query.is_empty() {
             return;
         }
-        // Case-insensitive search: scan the lowercased source.
-        let haystack = MARKDOWN.to_lowercase();
-        let needle = self.query.to_lowercase();
-        let mut start = 0;
-        while let Some(pos) = haystack[start..].find(&needle) {
-            let lo = start + pos;
-            let hi = lo + self.query.len();
-            self.matches.push(lo..hi);
-            start = lo + 1;
-        }
-        // Clamp active index in case the new query has fewer results.
-        if !self.matches.is_empty() {
-            self.active = self.active.min(self.matches.len() - 1);
-        } else {
-            self.active = 0;
+        let query = self.query.to_lowercase();
+        let qlen = query.len().max(1);
+        for (event, span) in Parser::new_ext(&self.content, pc_opts()).into_offset_iter() {
+            if let Event::Text(ref text) | Event::Code(ref text) = event {
+                collect_matches(text, span.start, &query, qlen, &mut self.matches);
+            }
         }
     }
 
-    /// Push the current matches into the cache so the viewer picks them up.
+    /// Push the current match ranges and active range into the cache.
     fn apply_to_cache(&mut self) {
-        self.cache.set_search_ranges(self.matches.clone());
+        let qlen = self.query.len();
+        let ranges: Vec<std::ops::Range<usize>> =
+            self.matches.iter().map(|&s| s..s + qlen).collect();
+        self.cache.set_search_ranges(ranges);
         self.cache
-            .set_active_search_range(self.matches.get(self.active).cloned());
+            .set_active_search_range(self.matches.get(self.active).map(|&s| s..s + qlen));
+    }
+
+    /// Scroll to the heading section that contains the active match.
+    fn scroll_to_active_match(&mut self) {
+        let Some(&byte_pos) = self.matches.get(self.active) else {
+            return;
+        };
+        if let Some((_, slug)) = self
+            .heading_positions
+            .iter()
+            .rev()
+            .find(|(pos, _)| *pos <= byte_pos)
+        {
+            *self.cache.scroll_to_id_target_mut() = Some(slug.clone());
+        }
     }
 }
 
@@ -88,6 +301,7 @@ impl eframe::App for App {
                 let response = ui.text_edit_singleline(&mut self.query);
                 if response.changed() {
                     self.update_matches();
+                    self.scroll_to_active_match();
                 }
 
                 let count = self.matches.len();
@@ -99,13 +313,15 @@ impl eframe::App for App {
                     ui.label(format!("{} / {}", self.active + 1, count));
                     if ui.button("Prev").clicked() {
                         self.active = (self.active + count - 1) % count;
+                        self.scroll_to_active_match();
                     }
                     if ui.button("Next").clicked() {
                         self.active = (self.active + 1) % count;
+                        self.scroll_to_active_match();
                     }
                 }
 
-                if !self.query.is_empty() && ui.button("✕").clicked() {
+                if !self.query.is_empty() && ui.button("\u{2716}").clicked() {
                     self.query.clear();
                     self.update_matches();
                 }
@@ -116,7 +332,11 @@ impl eframe::App for App {
             self.apply_to_cache();
 
             egui::ScrollArea::vertical().show(ui, |ui| {
-                CommonMarkViewer::new().show(ui, &mut self.cache, MARKDOWN);
+                CommonMarkViewer::new().enable_scroll_to_heading(true).show(
+                    ui,
+                    &mut self.cache,
+                    &self.content,
+                );
             });
         });
     }

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -1,23 +1,20 @@
 //! Demonstrates search-match highlighting with default colors.
 //!
 //! Typing in the search bar highlights every match. Prev/Next step through
-//! matches and scroll the document to the heading section containing each one.
+//! matches and scroll the document to centre each one in the viewport.
 //!
 //! Run with:
 //! `cargo r --example search [light|dark]`
 
-use std::collections::HashMap;
-
 use eframe::egui;
 use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
-use pulldown_cmark::{Event, Options, Parser, Tag};
 
 const MARKDOWN: &str = r#"# Search Highlighting
 
 Type text in the search bar above to highlight every occurrence in this document.
 Use **Prev** and **Next** to step through matches.
 
-Suggestion: try a search string like "MIT" to demonstrate scrolling to the matches.
+Suggestion: try searching for "MIT" to see scrolling to a match near the bottom.
 
 ---
 
@@ -66,230 +63,47 @@ Licensed under either of
 at your option.
 "#;
 
-fn pc_opts() -> Options {
-    Options::ENABLE_TABLES
-        | Options::ENABLE_TASKLISTS
-        | Options::ENABLE_STRIKETHROUGH
-        | Options::ENABLE_FOOTNOTES
-        | Options::ENABLE_HEADING_ATTRIBUTES
-}
-
-/// Converts heading text to a URL-safe slug: lowercased, non-alphanumeric runs
-/// replaced by `-`.
-fn slugify(text: &str) -> String {
-    let mut slug = String::with_capacity(text.len());
-    let mut prev_sep = true;
-    for ch in text.chars() {
-        if ch.is_alphanumeric() {
-            slug.push(ch.to_ascii_lowercase());
-            prev_sep = false;
-        } else if !prev_sep {
-            slug.push('-');
-            prev_sep = true;
-        }
-    }
-    if slug.ends_with('-') {
-        slug.pop();
-    }
-    slug
-}
-
-/// Parses an ATX heading line and returns `(level, plain_text)`, stripping any
-/// trailing `{…}` attribute block. Returns `None` for non-heading lines.
-#[allow(clippy::cast_possible_truncation)]
-fn parse_heading_line(line: &str) -> Option<(u8, &str)> {
-    let hashes = line.bytes().take_while(|&b| b == b'#').count();
-    if hashes == 0 || hashes > 6 {
-        return None;
-    }
-    let rest = line[hashes..].strip_prefix(' ')?;
-    let text = rest.trim_end();
-    if text.is_empty() {
-        return None;
-    }
-    let plain = text.rfind('{').map_or(text, |brace| {
-        let attr = text[brace..].trim_end();
-        if attr.ends_with('}') {
-            text[..brace].trim_end()
-        } else {
-            text
-        }
-    });
-    Some((hashes as u8, plain))
-}
-
-/// Returns the explicit `{#id}` from a heading line, if present.
-fn extract_heading_id(line: &str) -> Option<&str> {
-    let brace = line.rfind('{')?;
-    let attr = line[brace..].trim_end();
-    if attr.starts_with("{#") && attr.ends_with('}') {
-        Some(&attr[2..attr.len() - 1])
-    } else {
-        None
-    }
-}
-
-/// Scans `raw` markdown, injects `{#slug}` attributes into every heading that
-/// lacks one, and returns `(processed_content, slugs_in_order)`.
-///
-/// Uses pulldown-cmark as the heading oracle so that the injected IDs are
-/// consistent with what the renderer sees.
-fn inject_heading_ids(raw: &str) -> (String, Vec<String>) {
-    // Pass 1 — let pulldown-cmark locate the real heading starts.
-    let heading_starts: Vec<usize> = Parser::new_ext(raw, pc_opts())
-        .into_offset_iter()
-        .filter_map(|(event, span)| {
-            matches!(event, Event::Start(Tag::Heading { .. })).then_some(span.start)
-        })
-        .collect();
-
-    // Pass 2 — rebuild content, injecting `{#slug}` where needed.
-    let mut out = String::with_capacity(raw.len() + heading_starts.len() * 24);
-    let mut slugs: Vec<String> = Vec::new();
-    let mut slug_counts: HashMap<String, usize> = HashMap::new();
-    let mut pos = 0usize;
-
-    for line_start in heading_starts {
-        out.push_str(&raw[pos..line_start]);
-
-        let newline = raw[line_start..]
-            .find('\n')
-            .map_or(raw.len(), |p| line_start + p);
-        let line = &raw[line_start..newline];
-
-        if let Some((_level, plain_text)) = parse_heading_line(line) {
-            let (slug, injected) = extract_heading_id(line).map_or_else(
-                || {
-                    let base = slugify(plain_text);
-                    let n = slug_counts.entry(base.clone()).or_insert(0);
-                    let slug = if *n == 0 { base } else { format!("{base}-{n}") };
-                    *n += 1;
-                    let with_id = format!("{} {{#{slug}}}", line.trim_end());
-                    (slug, with_id)
-                },
-                |id| (id.to_string(), line.to_string()),
-            );
-            slugs.push(slug);
-            out.push_str(&injected);
-        } else {
-            // Setext or unrecognised heading — pass through unchanged.
-            out.push_str(line);
-        }
-
-        pos = if newline < raw.len() {
-            out.push('\n');
-            newline + 1
-        } else {
-            newline
-        };
-    }
-
-    out.push_str(&raw[pos..]);
-    (out, slugs)
-}
-
-/// Builds a `(byte_pos, slug)` list from the processed content and its slugs.
-/// The byte positions are content-relative (i.e. into the injected string).
-fn build_heading_positions(content: &str, slugs: &[String]) -> Vec<(usize, String)> {
-    let mut result = Vec::new();
-    let mut idx = 0;
-    for (event, span) in Parser::new_ext(content, pc_opts()).into_offset_iter() {
-        if matches!(event, Event::Start(Tag::Heading { .. })) {
-            if let Some(slug) = slugs.get(idx) {
-                result.push((span.start, slug.clone()));
-            }
-            idx += 1;
-        }
-    }
-    result
-}
-
-/// Appends the byte-start positions of all case-insensitive occurrences of
-/// `query` found within `text` to `out`. `span_start` is the offset of `text`
-/// within the full document.
-fn collect_matches(text: &str, span_start: usize, query: &str, qlen: usize, out: &mut Vec<usize>) {
-    let lower = text.to_lowercase();
-    let mut pos = 0;
-    while pos < lower.len() {
-        match lower[pos..].find(query) {
-            Some(rel) => {
-                out.push(span_start + pos + rel);
-                pos += rel + qlen;
-            }
-            None => break,
-        }
-    }
-}
-
 struct App {
-    /// Processed markdown with `{#slug}` IDs injected into every heading.
-    content: String,
     cache: CommonMarkCache,
     query: String,
-    /// Byte start positions of matches within `content`, in document order.
-    matches: Vec<usize>,
+    /// Byte-range matches into MARKDOWN, in document order.
+    matches: Vec<std::ops::Range<usize>>,
     /// Index of the active (focused) match.
     active: usize,
-    /// `(byte_pos, slug)` for each heading, used to scroll to the section
-    /// containing the active match.
-    heading_positions: Vec<(usize, String)>,
 }
 
 impl App {
     fn new() -> Self {
-        let (content, slugs) = inject_heading_ids(MARKDOWN);
-        let heading_positions = build_heading_positions(&content, &slugs);
         Self {
-            content,
             cache: CommonMarkCache::default(),
             query: String::new(),
             matches: Vec::new(),
             active: 0,
-            heading_positions,
         }
     }
 
-    /// Rebuild `matches` by searching inside every text-bearing pulldown-cmark
-    /// event. This excludes the injected `{#slug}` attributes and link
-    /// destinations, which are not visible in the rendered output.
+    /// Rebuild match ranges from a case-insensitive search over the raw source.
     fn update_matches(&mut self) {
         self.matches.clear();
         self.active = 0;
         if self.query.is_empty() {
             return;
         }
-        let query = self.query.to_lowercase();
-        let qlen = query.len().max(1);
-        for (event, span) in Parser::new_ext(&self.content, pc_opts()).into_offset_iter() {
-            if let Event::Text(ref text) | Event::Code(ref text) = event {
-                collect_matches(text, span.start, &query, qlen, &mut self.matches);
-            }
+        let haystack = MARKDOWN.to_lowercase();
+        let needle = self.query.to_lowercase();
+        let mut start = 0;
+        while let Some(pos) = haystack[start..].find(&needle) {
+            let lo = start + pos;
+            self.matches.push(lo..lo + self.query.len());
+            start = lo + 1;
         }
     }
 
     /// Push the current match ranges and active range into the cache.
     fn apply_to_cache(&mut self) {
-        let qlen = self.query.len();
-        let ranges: Vec<std::ops::Range<usize>> =
-            self.matches.iter().map(|&s| s..s + qlen).collect();
-        self.cache.set_search_ranges(ranges);
+        self.cache.set_search_ranges(self.matches.clone());
         self.cache
-            .set_active_search_range(self.matches.get(self.active).map(|&s| s..s + qlen));
-    }
-
-    /// Scroll to the heading section that contains the active match.
-    fn scroll_to_active_match(&mut self) {
-        let Some(&byte_pos) = self.matches.get(self.active) else {
-            return;
-        };
-        if let Some((_, slug)) = self
-            .heading_positions
-            .iter()
-            .rev()
-            .find(|(pos, _)| *pos <= byte_pos)
-        {
-            *self.cache.scroll_to_id_target_mut() = Some(slug.clone());
-        }
+            .set_active_search_range(self.matches.get(self.active).cloned());
     }
 }
 
@@ -301,7 +115,7 @@ impl eframe::App for App {
                 let response = ui.text_edit_singleline(&mut self.query);
                 if response.changed() {
                     self.update_matches();
-                    self.scroll_to_active_match();
+                    self.cache.set_scroll_to_active_match(true);
                 }
 
                 let count = self.matches.len();
@@ -313,15 +127,15 @@ impl eframe::App for App {
                     ui.label(format!("{} / {}", self.active + 1, count));
                     if ui.button("Prev").clicked() {
                         self.active = (self.active + count - 1) % count;
-                        self.scroll_to_active_match();
+                        self.cache.set_scroll_to_active_match(true);
                     }
                     if ui.button("Next").clicked() {
                         self.active = (self.active + 1) % count;
-                        self.scroll_to_active_match();
+                        self.cache.set_scroll_to_active_match(true);
                     }
                 }
 
-                if !self.query.is_empty() && ui.button("\u{2716}").clicked() {
+                if !self.query.is_empty() && ui.button("×").clicked() {
                     self.query.clear();
                     self.update_matches();
                 }
@@ -332,11 +146,7 @@ impl eframe::App for App {
             self.apply_to_cache();
 
             egui::ScrollArea::vertical().show(ui, |ui| {
-                CommonMarkViewer::new().enable_scroll_to_heading(true).show(
-                    ui,
-                    &mut self.cache,
-                    &self.content,
-                );
+                CommonMarkViewer::new().show(ui, &mut self.cache, MARKDOWN);
             });
         });
     }

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -1,0 +1,143 @@
+//! Demonstrates search-match highlighting with default colors.
+//!
+//! Run with:
+//! `cargo r --example search [light|dark]`
+
+use eframe::egui;
+use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
+
+const MARKDOWN: &str = "\
+# Search Highlighting
+
+Type text in the search bar above to highlight every occurrence in this document.
+Use **Prev** and **Next** to step through matches.
+
+## Rust
+
+Rust is a systems programming language focused on safety, speed, and concurrency.
+Rust achieves memory safety without a garbage collector.
+
+## Why Rust?
+
+Many developers choose Rust for its performance characteristics. The Rust compiler
+catches entire classes of bugs at compile time. Rust's ownership model ensures that
+data races are impossible.
+
+## Getting Started with Rust
+
+Install Rust via `rustup`. The Rust toolchain includes `cargo`, the build tool and
+package manager. Most Rust projects start with `cargo new`.
+";
+
+struct App {
+    cache: CommonMarkCache,
+    query: String,
+    /// Byte-range matches into MARKDOWN, in order.
+    matches: Vec<std::ops::Range<usize>>,
+    /// Index into `matches` for the active (focused) hit.
+    active: usize,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            cache: CommonMarkCache::default(),
+            query: String::new(),
+            matches: Vec::new(),
+            active: 0,
+        }
+    }
+
+    /// Recompute all match ranges for the current query.
+    fn update_matches(&mut self) {
+        self.matches.clear();
+        if self.query.is_empty() {
+            return;
+        }
+        // Case-insensitive search: scan the lowercased source.
+        let haystack = MARKDOWN.to_lowercase();
+        let needle = self.query.to_lowercase();
+        let mut start = 0;
+        while let Some(pos) = haystack[start..].find(&needle) {
+            let lo = start + pos;
+            let hi = lo + self.query.len();
+            self.matches.push(lo..hi);
+            start = lo + 1;
+        }
+        // Clamp active index in case the new query has fewer results.
+        if !self.matches.is_empty() {
+            self.active = self.active.min(self.matches.len() - 1);
+        } else {
+            self.active = 0;
+        }
+    }
+
+    /// Push the current matches into the cache so the viewer picks them up.
+    fn apply_to_cache(&mut self) {
+        self.cache.set_search_ranges(self.matches.clone());
+        self.cache
+            .set_active_search_range(self.matches.get(self.active).cloned());
+    }
+}
+
+impl eframe::App for App {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Search:");
+                let response = ui.text_edit_singleline(&mut self.query);
+                if response.changed() {
+                    self.update_matches();
+                }
+
+                let count = self.matches.len();
+                if count == 0 {
+                    if !self.query.is_empty() {
+                        ui.label("No matches");
+                    }
+                } else {
+                    ui.label(format!("{} / {}", self.active + 1, count));
+                    if ui.button("Prev").clicked() {
+                        self.active = (self.active + count - 1) % count;
+                    }
+                    if ui.button("Next").clicked() {
+                        self.active = (self.active + 1) % count;
+                    }
+                }
+
+                if !self.query.is_empty() && ui.button("✕").clicked() {
+                    self.query.clear();
+                    self.update_matches();
+                }
+            });
+
+            ui.separator();
+
+            self.apply_to_cache();
+
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                CommonMarkViewer::new().show(ui, &mut self.cache, MARKDOWN);
+            });
+        });
+    }
+}
+
+fn main() -> eframe::Result {
+    let mut args = std::env::args();
+    args.next();
+
+    eframe::run_native(
+        "Markdown search example",
+        eframe::NativeOptions::default(),
+        Box::new(move |cc| {
+            if let Some(theme) = args.next() {
+                if theme == "light" {
+                    cc.egui_ctx.set_theme(egui::Theme::Light);
+                } else if theme == "dark" {
+                    cc.egui_ctx.set_theme(egui::Theme::Dark);
+                }
+            }
+            Ok(Box::new(App::new()))
+        }),
+    )
+}

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -250,15 +250,25 @@ impl<'f> CommonMarkViewer<'f> {
     ) -> egui::InnerResponse<()> {
         egui_commonmark_backend::prepare_show(cache, ui.ctx());
 
-        let (response, _) = parsers::pulldown::CommonMarkViewerInternal::new().show(
-            ui,
-            cache,
-            &self.options,
-            text,
-            None,
-        );
-
-        response
+        // Wrap in a push_id keyed on the current search hit-set.  When
+        // search_ranges changes between frames, render_body_text splits text
+        // runs into a different number of ui.label() calls, shifting all widget
+        // counter values while the parent_id stays the same — triggering
+        // warn_if_rect_changes_id for every visible text segment.  Baking the
+        // ranges into the push_id salt means a different parent_id the moment
+        // the hit set changes, breaking the match condition.
+        let search_salt = cache.search_ranges().to_vec();
+        ui.push_id(("__cm_search", search_salt.as_slice()), |ui| {
+            let (response, _) = parsers::pulldown::CommonMarkViewerInternal::new().show(
+                ui,
+                cache,
+                &self.options,
+                text,
+                None,
+            );
+            response
+        })
+        .inner
     }
 
     /// Shows rendered markdown, and allows the rendered ui to mutate the source text.
@@ -273,14 +283,20 @@ impl<'f> CommonMarkViewer<'f> {
         self.options.mutable = true;
         egui_commonmark_backend::prepare_show(cache, ui.ctx());
 
-        let (mut inner_response, checkmark_events) =
-            parsers::pulldown::CommonMarkViewerInternal::new().show(
-                ui,
-                cache,
-                &self.options,
-                text,
-                None,
-            );
+        // Same push_id rationale as show(): suppress warn_if_rect_changes_id
+        // when the search hit set changes between frames.
+        let search_salt = cache.search_ranges().to_vec();
+        let (mut inner_response, checkmark_events) = ui
+            .push_id(("__cm_search", search_salt.as_slice()), |ui| {
+                parsers::pulldown::CommonMarkViewerInternal::new().show(
+                    ui,
+                    cache,
+                    &self.options,
+                    text,
+                    None,
+                )
+            })
+            .inner;
 
         // Update source text for checkmarks that were clicked
         for ev in checkmark_events {

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -371,7 +371,13 @@ impl List {
                 bullet_point(ui);
             }
         } else {
-            unreachable!();
+            // The list stack is empty.  This can happen in the viewport-cache
+            // path when the visible slice starts with a Start(Item) event whose
+            // enclosing Start(List) fell just outside the rendered window.
+            // Synthesise a top-level unordered list level so the item renders
+            // reasonably rather than panicking.
+            self.start_level_without_number();
+            bullet_point(ui);
         }
 
         ui.add_space(4.0);

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -300,7 +300,6 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// [`ScrollArea`]: egui::ScrollArea
     /// [`show`]: crate::CommonMarkViewer::show
-    #[doc(hidden)] // Buggy in scenarios more complex than the example application
     #[cfg(feature = "pulldown_cmark")]
     pub fn show_scrollable(
         self,

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -232,6 +232,15 @@ impl<'f> CommonMarkViewer<'f> {
         self
     }
 
+    /// When `true`, `show_scrollable` only renders the visible slice of the
+    /// document each frame, keeping large documents fast. When `false` (the
+    /// default) the full document is rendered and egui clips what is
+    /// off-screen, which is simpler and accurate enough for most documents.
+    pub fn viewport_cache(mut self, enable: bool) -> Self {
+        self.options.use_viewport_cache = enable;
+        self
+    }
+
     /// Shows rendered markdown
     pub fn show(
         self,

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -390,6 +390,10 @@ impl CommonMarkViewerInternal {
                             self.line.should_not_start_newline_forced = false;
                         }
                     }
+
+                    // Mirror show()'s deferred flush so that clicking a #fragment link
+                    // while in the viewport path also triggers a scroll next frame.
+                    *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
                 });
             });
 

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -821,21 +821,12 @@ impl CommonMarkViewerInternal {
             )
         };
 
-        let intervals: Vec<(usize, usize, bool)> = {
-            let active = cache.active_search_range();
-            cache
-                .search_ranges()
-                .iter()
-                .filter(|r| r.start < src_span.end && r.end > src_span.start)
-                .map(|r| {
-                    let local_start = r.start.saturating_sub(src_span.start).min(text.len());
-                    let local_end = r.end.saturating_sub(src_span.start).min(text.len());
-                    let is_active = active.is_some_and(|ar| ar.start == r.start && ar.end == r.end);
-                    (local_start, local_end, is_active)
-                })
-                .filter(|(s, e, _)| s < e)
-                .collect()
-        };
+        let intervals = search_intervals(
+            cache.search_ranges(),
+            cache.active_search_range(),
+            src_span,
+            text.len(),
+        );
 
         if intervals.is_empty() {
             ui.label(self.text_style.to_richtext(ui, text));
@@ -1090,5 +1081,119 @@ impl CommonMarkViewerInternal {
             block.end(ui, cache, options, max_width);
             self.line.try_insert_end(ui);
         }
+    }
+}
+
+/// Compute search-match intervals for one text run.
+///
+/// Filters `search_ranges` to those that overlap with `src_span`, converts
+/// them to byte offsets local to the text run (0-based, clamped to
+/// `text_len`), and flags each as active if it matches `active`.
+/// Zero-length intervals after clamping are discarded.
+fn search_intervals(
+    search_ranges: &[std::ops::Range<usize>],
+    active: Option<&std::ops::Range<usize>>,
+    src_span: std::ops::Range<usize>,
+    text_len: usize,
+) -> Vec<(usize, usize, bool)> {
+    search_ranges
+        .iter()
+        .filter(|r| r.start < src_span.end && r.end > src_span.start)
+        .map(|r| {
+            let local_start = r.start.saturating_sub(src_span.start).min(text_len);
+            let local_end = r.end.saturating_sub(src_span.start).min(text_len);
+            let is_active = active.is_some_and(|ar| ar.start == r.start && ar.end == r.end);
+            (local_start, local_end, is_active)
+        })
+        .filter(|(s, e, _)| s < e)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::search_intervals;
+
+    #[test]
+    fn no_ranges_gives_empty() {
+        assert!(search_intervals(&[], None, 0..10, 10).is_empty());
+    }
+
+    #[test]
+    fn range_entirely_before_span_excluded() {
+        assert!(search_intervals(&[0..5], None, 10..20, 10).is_empty());
+    }
+
+    #[test]
+    fn range_touching_span_start_excluded() {
+        // end == src_span.start does not satisfy r.end > src_span.start
+        assert!(search_intervals(&[5..10], None, 10..20, 10).is_empty());
+    }
+
+    #[test]
+    fn range_entirely_after_span_excluded() {
+        assert!(search_intervals(&[25..30], None, 10..20, 10).is_empty());
+    }
+
+    #[test]
+    fn range_touching_span_end_excluded() {
+        // start == src_span.end does not satisfy r.start < src_span.end
+        assert!(search_intervals(&[20..25], None, 10..20, 10).is_empty());
+    }
+
+    #[test]
+    fn range_fully_inside_span() {
+        let result = search_intervals(&[12..15], None, 10..20, 10);
+        assert_eq!(result, vec![(2, 5, false)]);
+    }
+
+    #[test]
+    fn range_starts_before_span_clipped_to_zero() {
+        let result = search_intervals(&[5..15], None, 10..20, 10);
+        assert_eq!(result, vec![(0, 5, false)]);
+    }
+
+    #[test]
+    fn range_ends_after_span_clipped_to_text_len() {
+        let result = search_intervals(&[15..25], None, 10..20, 10);
+        assert_eq!(result, vec![(5, 10, false)]);
+    }
+
+    #[test]
+    fn range_spans_entire_text() {
+        let result = search_intervals(&[5..30], None, 10..20, 10);
+        assert_eq!(result, vec![(0, 10, false)]);
+    }
+
+    #[test]
+    fn active_match_flagged_true() {
+        let active = 12..15;
+        let result = search_intervals(&[12..15], Some(&active), 10..20, 10);
+        assert_eq!(result, vec![(2, 5, true)]);
+    }
+
+    #[test]
+    fn different_active_does_not_flag_match() {
+        let active = 5..8;
+        let result = search_intervals(&[12..15], Some(&active), 10..20, 10);
+        assert_eq!(result, vec![(2, 5, false)]);
+    }
+
+    #[test]
+    fn multiple_ranges_all_mapped() {
+        let ranges = vec![11..13, 16..18];
+        let result = search_intervals(&ranges, None, 10..20, 10);
+        assert_eq!(result, vec![(1, 3, false), (6, 8, false)]);
+    }
+
+    #[test]
+    fn range_at_span_start_gives_local_zero() {
+        let result = search_intervals(&[10..13], None, 10..20, 10);
+        assert_eq!(result, vec![(0, 3, false)]);
+    }
+
+    #[test]
+    fn span_starts_at_document_origin() {
+        let result = search_intervals(&[2..5], None, 0..10, 10);
+        assert_eq!(result, vec![(2, 5, false)]);
     }
 }

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -289,11 +289,7 @@ impl CommonMarkViewerInternal {
                 .auto_shrink([false, true])
                 .show(ui, |ui| {
                     self.show(ui, cache, options, text, None);
-                    let delta =
-                        std::mem::replace(&mut cache.pending_scroll_delta, egui::Vec2::ZERO);
-                    if delta != egui::Vec2::ZERO {
-                        ui.scroll_with_delta(delta);
-                    }
+                    apply_pending_scroll_delta(cache, ui);
                 });
             return;
         }
@@ -304,11 +300,7 @@ impl CommonMarkViewerInternal {
                 .auto_shrink([false, true])
                 .show(ui, |ui| {
                     self.show(ui, cache, options, text, Some(source_id));
-                    let delta =
-                        std::mem::replace(&mut cache.pending_scroll_delta, egui::Vec2::ZERO);
-                    if delta != egui::Vec2::ZERO {
-                        ui.scroll_with_delta(delta);
-                    }
+                    apply_pending_scroll_delta(cache, ui);
                 });
             scroll_cache(cache, &source_id).available_size = available_size;
             return;
@@ -809,17 +801,11 @@ impl CommonMarkViewerInternal {
         text: &str,
         src_span: Range<usize>,
     ) {
-        let (match_bg, active_bg) = if ui.visuals().dark_mode {
-            (
-                egui::Color32::from_rgb(30, 115, 105),
-                egui::Color32::from_rgb(95, 75, 165),
-            )
-        } else {
-            (
-                egui::Color32::from_rgb(140, 220, 210),
-                egui::Color32::from_rgb(185, 165, 240),
-            )
-        };
+        let selection_bg = ui.visuals().selection.bg_fill;
+        let active_bg = cache.active_search_match_bg.unwrap_or(selection_bg);
+        let match_bg = cache
+            .search_match_bg
+            .unwrap_or_else(|| selection_bg.gamma_multiply(0.6));
 
         let intervals = search_intervals(
             cache.search_ranges(),
@@ -843,7 +829,19 @@ impl CommonMarkViewerInternal {
             }
             if let Some(slice) = text.get(*start..*end) {
                 let bg = if *is_active { active_bg } else { match_bg };
-                ui.label(self.text_style.to_richtext(ui, slice).background_color(bg));
+                let rich = if self.text_style.code {
+                    // .code() paints a gray background that overrides background_color,
+                    // so we apply the monospace font directly instead.
+                    let mut style = self.text_style.clone();
+                    style.code = false;
+                    style
+                        .to_richtext(ui, slice)
+                        .text_style(egui::TextStyle::Monospace)
+                        .background_color(bg)
+                } else {
+                    self.text_style.to_richtext(ui, slice).background_color(bg)
+                };
+                ui.label(rich);
             }
             pos = *end;
         }
@@ -1081,6 +1079,13 @@ impl CommonMarkViewerInternal {
             block.end(ui, cache, options, max_width);
             self.line.try_insert_end(ui);
         }
+    }
+}
+
+fn apply_pending_scroll_delta(cache: &mut CommonMarkCache, ui: &mut Ui) {
+    let delta = std::mem::replace(&mut cache.pending_scroll_delta, egui::Vec2::ZERO);
+    if delta != egui::Vec2::ZERO {
+        ui.scroll_with_delta(delta);
     }
 }
 

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -913,10 +913,10 @@ impl CommonMarkViewerInternal {
                 }
             }
             pulldown_cmark::TagEnd::Image => {
-                if let Some(image) = self.image.take() {
-                    if image.end(ui, options) < 1.0 {
-                        self.any_image_loading = true;
-                    }
+                if let Some(image) = self.image.take()
+                    && image.end(ui, options) < 1.0
+                {
+                    self.any_image_loading = true;
                 }
             }
             pulldown_cmark::TagEnd::HtmlBlock => {

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -84,6 +84,10 @@ pub struct CommonMarkViewerInternal {
     is_blockquote: bool,
     checkbox_events: Vec<CheckboxClickEvent>,
     deferred_scroll_to_heading: Option<String>,
+    /// Set during a full render if any image rendered at zero height (texture
+    /// still loading). When true, split points are discarded and the full render
+    /// repeats next frame until all images have stable heights.
+    any_image_loading: bool,
 }
 
 pub(crate) struct CheckboxClickEvent {
@@ -108,6 +112,7 @@ impl CommonMarkViewerInternal {
             is_blockquote: false,
             checkbox_events: Vec::new(),
             deferred_scroll_to_heading: None,
+            any_image_loading: false,
         }
     }
 }
@@ -137,6 +142,7 @@ impl CommonMarkViewerInternal {
         text: &str,
         split_points_id: Option<Id>,
     ) -> (egui::InnerResponse<()>, Vec<CheckboxClickEvent>) {
+        self.any_image_loading = false;
         let max_width = options.max_width(ui);
         let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
 
@@ -153,10 +159,56 @@ impl CommonMarkViewerInternal {
             .enumerate()
             .peekable();
 
+            // Screen-space y of the content origin. Subtracting this from any
+            // cursor position gives virtual (content-relative) y comparable to
+            // viewport.min/max.y from show_viewport.
+            let content_origin_y = ui.next_widget_position().y;
+
+            // Cursor at the visual top of the current block, captured at
+            // Start(Block) so that vstart reflects the block top, not its bottom.
+            let mut block_start_position: Option<Pos2> = None;
+
             while let Some((index, (e, src_span))) = events.next() {
                 let start_position = ui.next_widget_position();
-                let is_element_end = matches!(e, pulldown_cmark::Event::End(_));
-                let should_add_split_point = self.list.is_inside_a_list() && is_element_end;
+
+                let is_safe_block_start = !self.list.is_inside_a_list()
+                    && matches!(
+                        e,
+                        pulldown_cmark::Event::Start(
+                            pulldown_cmark::Tag::Paragraph
+                                | pulldown_cmark::Tag::Heading { .. }
+                                | pulldown_cmark::Tag::CodeBlock(_)
+                        )
+                    );
+                if is_safe_block_start {
+                    block_start_position = Some(start_position);
+                }
+
+                // Record virtual y for each named heading so the viewport path
+                // can jump to headings that are outside the rendered slice.
+                if let (
+                    Some(sid),
+                    pulldown_cmark::Event::Start(pulldown_cmark::Tag::Heading {
+                        id: Some(id), ..
+                    }),
+                ) = (split_points_id, &e)
+                {
+                    scroll_cache(cache, &sid)
+                        .heading_y_positions
+                        .insert(id.to_string(), ui.cursor().min.y - content_origin_y);
+                }
+
+                // Only record split points at clean, top-level block boundaries
+                // where the renderer has no pending state and can restart safely.
+                let is_safe_block_end = !self.list.is_inside_a_list()
+                    && matches!(
+                        e,
+                        pulldown_cmark::Event::End(
+                            pulldown_cmark::TagEnd::Paragraph
+                                | pulldown_cmark::TagEnd::Heading { .. }
+                                | pulldown_cmark::TagEnd::CodeBlock
+                        )
+                    );
 
                 if events.peek().is_none() {
                     self.line.should_end_newline_forced = false;
@@ -165,7 +217,7 @@ impl CommonMarkViewerInternal {
                 self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
 
                 if let Some(source_id) = split_points_id
-                    && should_add_split_point
+                    && is_safe_block_end
                 {
                     let scroll_cache = scroll_cache(cache, &source_id);
                     let end_position = ui.next_widget_position();
@@ -176,9 +228,12 @@ impl CommonMarkViewerInternal {
                         .any(|(i, _, _)| *i == index);
 
                     if !split_point_exists {
-                        scroll_cache
-                            .split_points
-                            .push((index, start_position, end_position));
+                        // Use block_start_position (Start event) not start_position
+                        // (cursor just before End) so that vstart is the block top.
+                        let raw_vstart = block_start_position.take().unwrap_or(start_position);
+                        let vstart = egui::pos2(raw_vstart.x, raw_vstart.y - content_origin_y);
+                        let vend = egui::pos2(end_position.x, end_position.y - content_origin_y);
+                        scroll_cache.split_points.push((index, vstart, vend));
                     }
                 }
 
@@ -191,8 +246,18 @@ impl CommonMarkViewerInternal {
             *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
 
             if let Some(source_id) = split_points_id {
-                scroll_cache(cache, &source_id).page_size =
-                    Some(ui.next_widget_position().to_vec2());
+                if self.any_image_loading {
+                    // Images are still loading — split points are unreliable.
+                    // Discard and leave page_size = None so the full render repeats
+                    // next frame (the image loader triggers the repaint automatically).
+                    let sc = scroll_cache(cache, &source_id);
+                    sc.split_points.clear();
+                    sc.heading_y_positions.clear();
+                } else {
+                    let final_y = ui.next_widget_position().y;
+                    scroll_cache(cache, &source_id).page_size =
+                        Some(egui::vec2(max_width, final_y - content_origin_y));
+                }
             }
         });
 
@@ -217,7 +282,6 @@ impl CommonMarkViewerInternal {
                 .show(ui, |ui| {
                     self.show(ui, cache, options, text, Some(source_id));
                 });
-            // Prevent repopulating points twice at startup
             scroll_cache(cache, &source_id).available_size = available_size;
             return;
         };
@@ -231,6 +295,23 @@ impl CommonMarkViewerInternal {
 
         let num_rows = events.len();
 
+        // Resolve any pending TOC scroll via the cached heading positions so that
+        // navigation works even when the target is outside the rendered slice.
+        let pending_scroll_y: Option<f32> = {
+            let slug_owned = cache.scroll_to_id_target().map(|s| s.to_owned());
+            if let Some(ref slug) = slug_owned {
+                let sc = scroll_cache(cache, &source_id);
+                if let Some(&y) = sc.heading_y_positions.get(slug) {
+                    cache.scroll_to_id_target_mut().take();
+                    Some(y)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+
         egui::ScrollArea::vertical()
             .id_salt(scroll_id)
             // Elements have different widths, so the scroll area cannot try to shrink to the
@@ -238,6 +319,17 @@ impl CommonMarkViewerInternal {
             // with different widths.
             .auto_shrink([false, true])
             .show_viewport(ui, |ui, viewport| {
+                if let Some(y) = pending_scroll_y {
+                    // heading_y_positions stores virtual y (content-relative, 0 = top).
+                    // Inside show_viewport, next_widget_position().y = screen_top − scroll.
+                    // scroll_to_rect with Align::TOP sets new_scroll = y. ✓
+                    let r = egui::Rect::from_min_size(
+                        egui::pos2(0.0, ui.next_widget_position().y + y),
+                        egui::Vec2::ZERO,
+                    );
+                    ui.scroll_to_rect(r, Some(egui::Align::TOP));
+                }
+
                 ui.set_height(page_size.y);
                 let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
 
@@ -246,41 +338,54 @@ impl CommonMarkViewerInternal {
                     ui.spacing_mut().item_spacing.x = 0.0;
                     let scroll_cache = scroll_cache(cache, &source_id);
 
-                    // finding the first element that's not in the viewport anymore
-                    let (first_event_index, _, first_end_position) = scroll_cache
+                    // Render one full viewport-height below the visible bottom so
+                    // that scrolling down never reveals a trailing blank region.
+                    let viewport_height = viewport.max.y - viewport.min.y;
+                    let render_below = viewport.max.y + viewport_height;
+
+                    let preceding_split = scroll_cache
                         .split_points
                         .iter()
-                        .filter(|(_, _, end_position)| end_position.y < viewport.min.y)
-                        .nth_back(1)
-                        .copied()
-                        .unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
+                        .rfind(|(_, _, vend)| vend.y < viewport.min.y)
+                        .copied();
 
-                    // finding the last element that's just outside the viewport
+                    let (_first_event_index, _, first_end_position) =
+                        preceding_split.unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
+
                     let last_event_index = scroll_cache
                         .split_points
                         .iter()
-                        .filter(|(_, start_position, _)| start_position.y > viewport.max.y)
-                        .nth(1)
+                        .find(|(_, vstart, _)| vstart.y > render_below)
                         .map(|(index, _, _)| *index)
                         .unwrap_or(num_rows);
 
-                    ui.allocate_space(first_end_position.to_vec2());
+                    // Allocate a full-width block for the off-screen content so
+                    // that the cursor lands at the correct x for the first visible block.
+                    let skip_height = first_end_position.y.max(0.0);
+                    ui.allocate_space(egui::vec2(max_width, skip_height));
 
-                    // only rendering the elements that are inside the viewport
+                    // When a preceding split was found, its End(Block) is already
+                    // accounted for in skip_height — re-processing it would add a
+                    // duplicate newline. Start from the next event instead.
+                    let (skip_count, take_count) = if let Some((idx, _, _)) = preceding_split {
+                        self.line.should_not_start_newline_forced = false;
+                        (idx + 1, last_event_index - idx)
+                    } else {
+                        (0, last_event_index)
+                    };
+
                     let mut events = events
                         .into_iter()
                         .enumerate()
-                        .skip(first_event_index)
-                        .take(last_event_index - first_event_index)
+                        .skip(skip_count)
+                        .take(take_count)
                         .peekable();
 
                     while let Some((i, (e, src_span))) = events.next() {
                         if events.peek().is_none() {
                             self.line.should_end_newline_forced = false;
                         }
-
                         self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
-
                         if i == 0 {
                             self.line.should_not_start_newline_forced = false;
                         }
@@ -288,12 +393,22 @@ impl CommonMarkViewerInternal {
                 });
             });
 
-        // Forcing full re-render to repopulate split points for the new size
+        // If any image in this render reported zero height, split points are stale.
+        // Discard them so the next frame falls back to a full render.
+        if self.any_image_loading {
+            let sc = scroll_cache(cache, &source_id);
+            sc.page_size = None;
+            sc.split_points.clear();
+            sc.heading_y_positions.clear();
+        }
+
+        // Invalidate the cache when the available size changes (e.g. window resize).
         let scroll_cache = scroll_cache(cache, &source_id);
         if available_size != scroll_cache.available_size {
             scroll_cache.available_size = available_size;
             scroll_cache.page_size = None;
             scroll_cache.split_points.clear();
+            scroll_cache.heading_y_positions.clear();
         }
     }
 
@@ -795,7 +910,9 @@ impl CommonMarkViewerInternal {
             }
             pulldown_cmark::TagEnd::Image => {
                 if let Some(image) = self.image.take() {
-                    image.end(ui, options);
+                    if image.end(ui, options) < 1.0 {
+                        self.any_image_loading = true;
+                    }
                 }
             }
             pulldown_cmark::TagEnd::HtmlBlock => {

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -275,12 +275,40 @@ impl CommonMarkViewerInternal {
         let available_size = ui.available_size();
         let scroll_id = source_id.with("_scroll_area");
 
+        if !options.use_viewport_cache {
+            // Simple path: render the full document every frame; egui clips
+            // what is off-screen. Clears any stale cache from a previous run.
+            {
+                let sc = scroll_cache(cache, &source_id);
+                sc.page_size = None;
+                sc.split_points.clear();
+                sc.heading_y_positions.clear();
+            }
+            egui::ScrollArea::vertical()
+                .id_salt(scroll_id)
+                .auto_shrink([false, true])
+                .show(ui, |ui| {
+                    self.show(ui, cache, options, text, None);
+                    let delta =
+                        std::mem::replace(&mut cache.pending_scroll_delta, egui::Vec2::ZERO);
+                    if delta != egui::Vec2::ZERO {
+                        ui.scroll_with_delta(delta);
+                    }
+                });
+            return;
+        }
+
         let Some(page_size) = scroll_cache(cache, &source_id).page_size else {
             egui::ScrollArea::vertical()
                 .id_salt(scroll_id)
                 .auto_shrink([false, true])
                 .show(ui, |ui| {
                     self.show(ui, cache, options, text, Some(source_id));
+                    let delta =
+                        std::mem::replace(&mut cache.pending_scroll_delta, egui::Vec2::ZERO);
+                    if delta != egui::Vec2::ZERO {
+                        ui.scroll_with_delta(delta);
+                    }
                 });
             scroll_cache(cache, &source_id).available_size = available_size;
             return;
@@ -311,6 +339,7 @@ impl CommonMarkViewerInternal {
                 None
             }
         };
+        let pending_delta = std::mem::replace(&mut cache.pending_scroll_delta, egui::Vec2::ZERO);
 
         egui::ScrollArea::vertical()
             .id_salt(scroll_id)
@@ -328,6 +357,9 @@ impl CommonMarkViewerInternal {
                         egui::Vec2::ZERO,
                     );
                     ui.scroll_to_rect(r, Some(egui::Align::TOP));
+                }
+                if pending_delta != egui::Vec2::ZERO {
+                    ui.scroll_with_delta(pending_delta);
                 }
 
                 ui.set_height(page_size.y);
@@ -692,22 +724,22 @@ impl CommonMarkViewerInternal {
             pulldown_cmark::Event::Start(tag) => self.start_tag(ui, tag, cache, options),
             pulldown_cmark::Event::End(tag) => self.end_tag(ui, tag, cache, options, max_width),
             pulldown_cmark::Event::Text(text) => {
-                self.event_text(text, ui);
+                self.event_text(text, src_span, ui, cache);
             }
             pulldown_cmark::Event::Code(text) => {
                 self.text_style.code = true;
-                self.event_text(text, ui);
+                self.event_text(text, src_span, ui, cache);
                 self.text_style.code = false;
             }
             pulldown_cmark::Event::InlineHtml(text) => {
-                self.event_text(text, ui);
+                self.event_text(text, src_span, ui, cache);
             }
 
             pulldown_cmark::Event::Html(text) => {
                 if options.html_fn.is_some() {
                     self.html_block.push_str(&text);
                 } else {
-                    self.event_text(text, ui);
+                    self.event_text(text, src_span, ui, cache);
                 }
             }
             pulldown_cmark::Event::FootnoteReference(footnote) => {
@@ -749,16 +781,85 @@ impl CommonMarkViewerInternal {
         }
     }
 
-    fn event_text(&mut self, text: CowStr, ui: &mut Ui) {
-        let rich_text = self.text_style.to_richtext(ui, &text);
+    fn event_text(
+        &mut self,
+        text: CowStr,
+        src_span: Range<usize>,
+        ui: &mut Ui,
+        cache: &mut CommonMarkCache,
+    ) {
         if let Some(image) = &mut self.image {
-            image.alt_text.push(rich_text);
+            image.alt_text.push(self.text_style.to_richtext(ui, &text));
         } else if let Some(block) = &mut self.code_block {
             block.content.push_str(&text);
         } else if let Some(link) = &mut self.link {
-            link.text.push(rich_text);
+            link.text.push(self.text_style.to_richtext(ui, &text));
         } else {
-            ui.label(rich_text);
+            self.render_body_text(ui, cache, &text, src_span);
+        }
+    }
+
+    /// Render a body-text run, splitting at search-match boundaries and
+    /// painting a background on each hit. Falls back to a plain label when
+    /// there are no overlapping search ranges.
+    fn render_body_text(
+        &self,
+        ui: &mut Ui,
+        cache: &CommonMarkCache,
+        text: &str,
+        src_span: Range<usize>,
+    ) {
+        let (match_bg, active_bg) = if ui.visuals().dark_mode {
+            (
+                egui::Color32::from_rgb(30, 115, 105),
+                egui::Color32::from_rgb(95, 75, 165),
+            )
+        } else {
+            (
+                egui::Color32::from_rgb(140, 220, 210),
+                egui::Color32::from_rgb(185, 165, 240),
+            )
+        };
+
+        let intervals: Vec<(usize, usize, bool)> = {
+            let active = cache.active_search_range();
+            cache
+                .search_ranges()
+                .iter()
+                .filter(|r| r.start < src_span.end && r.end > src_span.start)
+                .map(|r| {
+                    let local_start = r.start.saturating_sub(src_span.start).min(text.len());
+                    let local_end = r.end.saturating_sub(src_span.start).min(text.len());
+                    let is_active = active.is_some_and(|ar| ar.start == r.start && ar.end == r.end);
+                    (local_start, local_end, is_active)
+                })
+                .filter(|(s, e, _)| s < e)
+                .collect()
+        };
+
+        if intervals.is_empty() {
+            ui.label(self.text_style.to_richtext(ui, text));
+            return;
+        }
+
+        // item_spacing.x is already 0 in the outer layout so segments flow without gaps.
+        let mut pos = 0usize;
+        for (start, end, is_active) in &intervals {
+            if pos < *start
+                && let Some(slice) = text.get(pos..*start)
+            {
+                ui.label(self.text_style.to_richtext(ui, slice));
+            }
+            if let Some(slice) = text.get(*start..*end) {
+                let bg = if *is_active { active_bg } else { match_bg };
+                ui.label(self.text_style.to_richtext(ui, slice).background_color(bg));
+            }
+            pos = *end;
+        }
+        if pos < text.len()
+            && let Some(slice) = text.get(pos..)
+        {
+            ui.label(self.text_style.to_richtext(ui, slice));
         }
     }
 

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -336,43 +336,39 @@ impl CommonMarkViewerInternal {
                 let max_width = options.max_width(ui);
                 ui.allocate_ui_with_layout(egui::vec2(max_width, 0.0), layout, |ui| {
                     ui.spacing_mut().item_spacing.x = 0.0;
-                    let scroll_cache = scroll_cache(cache, &source_id);
 
-                    // Render one full viewport-height below the visible bottom so
-                    // that scrolling down never reveals a trailing blank region.
+                    // Compute the slice parameters and release the scroll_cache borrow
+                    // before the push_id closure so that `cache` is freely accessible
+                    // inside it.
                     let viewport_height = viewport.max.y - viewport.min.y;
                     let render_below = viewport.max.y + viewport_height;
-
-                    let preceding_split = scroll_cache
-                        .split_points
-                        .iter()
-                        .rfind(|(_, _, vend)| vend.y < viewport.min.y)
-                        .copied();
-
-                    let (_first_event_index, _, first_end_position) =
-                        preceding_split.unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
-
-                    let last_event_index = scroll_cache
-                        .split_points
-                        .iter()
-                        .find(|(_, vstart, _)| vstart.y > render_below)
-                        .map(|(index, _, _)| *index)
-                        .unwrap_or(num_rows);
-
-                    // Allocate a full-width block for the off-screen content so
-                    // that the cursor lands at the correct x for the first visible block.
-                    let skip_height = first_end_position.y.max(0.0);
-                    ui.allocate_space(egui::vec2(max_width, skip_height));
-
-                    // When a preceding split was found, its End(Block) is already
-                    // accounted for in skip_height — re-processing it would add a
-                    // duplicate newline. Start from the next event instead.
-                    let (skip_count, take_count) = if let Some((idx, _, _)) = preceding_split {
-                        self.line.should_not_start_newline_forced = false;
-                        (idx + 1, last_event_index - idx)
-                    } else {
-                        (0, last_event_index)
-                    };
+                    let (skip_height, skip_count, take_count) = {
+                        let scroll_cache = scroll_cache(cache, &source_id);
+                        let preceding_split = scroll_cache
+                            .split_points
+                            .iter()
+                            .rfind(|(_, _, vend)| vend.y < viewport.min.y)
+                            .copied();
+                        let (_first_event_index, _, first_end_position) =
+                            preceding_split.unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
+                        let last_event_index = scroll_cache
+                            .split_points
+                            .iter()
+                            .find(|(_, vstart, _)| vstart.y > render_below)
+                            .map(|(index, _, _)| *index)
+                            .unwrap_or(num_rows);
+                        let skip_height = first_end_position.y.max(0.0);
+                        // When a preceding split was found, its End(Block) is already
+                        // accounted for in skip_height — re-processing it would add a
+                        // duplicate newline. Start from the next event instead.
+                        let (skip_count, take_count) = if let Some((idx, _, _)) = preceding_split {
+                            self.line.should_not_start_newline_forced = false;
+                            (idx + 1, last_event_index - idx)
+                        } else {
+                            (0, last_event_index)
+                        };
+                        (skip_height, skip_count, take_count)
+                    }; // scroll_cache borrow released here
 
                     let mut events = events
                         .into_iter()
@@ -381,19 +377,48 @@ impl CommonMarkViewerInternal {
                         .take(take_count)
                         .peekable();
 
-                    while let Some((i, (e, src_span))) = events.next() {
-                        if events.peek().is_none() {
-                            self.line.should_end_newline_forced = false;
-                        }
-                        self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
-                        if i == 0 {
-                            self.line.should_not_start_newline_forced = false;
-                        }
-                    }
+                    // Give the viewport render a distinct widget parent_id namespace
+                    // from the full-render path.  egui's warn_if_rect_changes_id check
+                    // only fires when the same screen rect has different widget IDs
+                    // *and* at least one widget shares a parent_id between consecutive
+                    // frames.  Using a different salt here vs the full-render path makes
+                    // the parent_id comparison always fail on the transition frame,
+                    // eliminating the spurious one-frame red outlines on image load and
+                    // window resize.
+                    //
+                    // IMPORTANT: push_id must be called BEFORE allocate_space so that
+                    // the cursor is still at (0, 0) — the left edge of a full-width row.
+                    // Calling it after allocate_space leaves the cursor at (max_width, …)
+                    // (right edge), making available_rect_before_wrap() return a
+                    // near-zero width and collapsing all content to a 1-pixel stripe.
+                    ui.push_id("__cm_viewport", |ui| {
+                        // Skip over off-screen content by reserving its vertical space.
+                        // Full width is essential: a narrower allocation would leave
+                        // the cursor mid-row, misaligning the first visible block.
+                        ui.allocate_space(egui::vec2(max_width, skip_height));
 
-                    // Mirror show()'s deferred flush so that clicking a #fragment link
-                    // while in the viewport path also triggers a scroll next frame.
-                    *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
+                        while let Some((i, (e, src_span))) = events.next() {
+                            if events.peek().is_none() {
+                                self.line.should_end_newline_forced = false;
+                            }
+                            self.process_event(
+                                ui,
+                                &mut events,
+                                e,
+                                src_span,
+                                cache,
+                                options,
+                                max_width,
+                            );
+                            if i == 0 {
+                                self.line.should_not_start_newline_forced = false;
+                            }
+                        }
+
+                        // Mirror show()'s deferred flush so that clicking a #fragment
+                        // link while in the viewport path triggers a scroll next frame.
+                        *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
+                    });
                 });
             });
 

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -284,22 +284,34 @@ impl CommonMarkViewerInternal {
                 sc.split_points.clear();
                 sc.heading_y_positions.clear();
             }
+            // Snapshot search ranges before the ScrollArea closure so the
+            // immutable borrow ends here (cache is used mutably inside).
+            let search_salt = cache.search_ranges().to_vec();
             egui::ScrollArea::vertical()
                 .id_salt(scroll_id)
                 .auto_shrink([false, true])
                 .show(ui, |ui| {
-                    self.show(ui, cache, options, text, None);
+                    // push_id keyed on search_ranges: when the hit set changes,
+                    // the parent_id changes too, suppressing
+                    // warn_if_rect_changes_id (same rationale as show()).
+                    ui.push_id(("__cm_search", search_salt.as_slice()), |ui| {
+                        self.show(ui, cache, options, text, None);
+                    });
                     apply_pending_scroll_delta(cache, ui);
                 });
             return;
         }
 
         let Some(page_size) = scroll_cache(cache, &source_id).page_size else {
+            // Snapshot before the closure for the same borrow-split reason.
+            let search_salt = cache.search_ranges().to_vec();
             egui::ScrollArea::vertical()
                 .id_salt(scroll_id)
                 .auto_shrink([false, true])
                 .show(ui, |ui| {
-                    self.show(ui, cache, options, text, Some(source_id));
+                    ui.push_id(("__cm_search", search_salt.as_slice()), |ui| {
+                        self.show(ui, cache, options, text, Some(source_id));
+                    });
                     apply_pending_scroll_delta(cache, ui);
                 });
             scroll_cache(cache, &source_id).available_size = available_size;
@@ -398,6 +410,12 @@ impl CommonMarkViewerInternal {
                         (skip_height, skip_count, take_count)
                     }; // scroll_cache borrow released here
 
+                    // Snapshot the search ranges before the push_id closure so
+                    // that the immutable borrow of `cache` ends here, allowing
+                    // the closure to take `cache` mutably.  The snapshot is used
+                    // as part of the push_id salt (see the comment below).
+                    let search_ranges_salt = cache.search_ranges().to_vec();
+
                     let mut events = events
                         .into_iter()
                         .enumerate()
@@ -424,6 +442,15 @@ impl CommonMarkViewerInternal {
                     // slice renders with identical counter values → same IDs → no
                     // warning then either.
                     //
+                    // search_ranges is also included in the salt because active search
+                    // results cause render_body_text to split text runs into multiple
+                    // ui.label() calls (one per segment between match boundaries).  If
+                    // the search query changes between frames while skip_count stays
+                    // the same, the widget counter sequence changes for the same slice
+                    // → same rect, same parent_id, different ID → warning fires.  Baking
+                    // the ranges into the salt ensures the parent_id changes whenever
+                    // the hit set changes, breaking the parent_id match condition.
+                    //
                     // The salt tuple also differs from the full-render path's implicit
                     // parent (no push_id), so the transition-frame guard from the
                     // full→viewport fix remains intact.
@@ -433,34 +460,38 @@ impl CommonMarkViewerInternal {
                     // row.  Calling it after allocate_space leaves the cursor at
                     // (max_width, …) (right edge), making available_rect_before_wrap()
                     // return near-zero width and collapsing all content to a thin strip.
-                    ui.push_id(("__cm_viewport", skip_count), |ui| {
-                        // Skip over off-screen content by reserving its vertical space.
-                        // Full width is essential: a narrower allocation would leave
-                        // the cursor mid-row, misaligning the first visible block.
-                        ui.allocate_space(egui::vec2(max_width, skip_height));
+                    ui.push_id(
+                        ("__cm_viewport", skip_count, search_ranges_salt.as_slice()),
+                        |ui| {
+                            // Skip over off-screen content by reserving its vertical space.
+                            // Full width is essential: a narrower allocation would leave
+                            // the cursor mid-row, misaligning the first visible block.
+                            ui.allocate_space(egui::vec2(max_width, skip_height));
 
-                        while let Some((i, (e, src_span))) = events.next() {
-                            if events.peek().is_none() {
-                                self.line.should_end_newline_forced = false;
+                            while let Some((i, (e, src_span))) = events.next() {
+                                if events.peek().is_none() {
+                                    self.line.should_end_newline_forced = false;
+                                }
+                                self.process_event(
+                                    ui,
+                                    &mut events,
+                                    e,
+                                    src_span,
+                                    cache,
+                                    options,
+                                    max_width,
+                                );
+                                if i == 0 {
+                                    self.line.should_not_start_newline_forced = false;
+                                }
                             }
-                            self.process_event(
-                                ui,
-                                &mut events,
-                                e,
-                                src_span,
-                                cache,
-                                options,
-                                max_width,
-                            );
-                            if i == 0 {
-                                self.line.should_not_start_newline_forced = false;
-                            }
-                        }
 
-                        // Mirror show()'s deferred flush so that clicking a #fragment
-                        // link while in the viewport path triggers a scroll next frame.
-                        *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
-                    });
+                            // Mirror show()'s deferred flush so that clicking a #fragment
+                            // link while in the viewport path triggers a scroll next frame.
+                            *cache.scroll_to_id_target_mut() =
+                                self.deferred_scroll_to_heading.take();
+                        },
+                    );
                 });
             });
 

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -382,20 +382,34 @@ impl CommonMarkViewerInternal {
                         .peekable();
 
                     // Give the viewport render a distinct widget parent_id namespace
-                    // from the full-render path.  egui's warn_if_rect_changes_id check
-                    // only fires when the same screen rect has different widget IDs
-                    // *and* at least one widget shares a parent_id between consecutive
-                    // frames.  Using a different salt here vs the full-render path makes
-                    // the parent_id comparison always fail on the transition frame,
-                    // eliminating the spurious one-frame red outlines on image load and
-                    // window resize.
+                    // so that egui's warn_if_rect_changes_id check never fires.
+                    //
+                    // The check fires when the same screen rect has different widget
+                    // IDs *and* at least one widget shares a parent_id between
+                    // consecutive frames.  Widget IDs within this push_id scope are
+                    // counter-based (sequential from 0 each frame).  The counter
+                    // resets at the start of each rendered slice, so when skip_count
+                    // advances by 1 (viewport crosses a split-point boundary), every
+                    // widget in the visible overlap shifts its ID by 1 — same rect,
+                    // same parent_id, different ID → warning fires.
+                    //
+                    // Fix: bake skip_count into the push_id salt.  Consecutive frames
+                    // with different skip_count values get different parent_ids, so the
+                    // parent_id match condition is never met.  When skip_count is
+                    // stable (viewport moves within a split-point interval), the same
+                    // slice renders with identical counter values → same IDs → no
+                    // warning then either.
+                    //
+                    // The salt tuple also differs from the full-render path's implicit
+                    // parent (no push_id), so the transition-frame guard from the
+                    // full→viewport fix remains intact.
                     //
                     // IMPORTANT: push_id must be called BEFORE allocate_space so that
-                    // the cursor is still at (0, 0) — the left edge of a full-width row.
-                    // Calling it after allocate_space leaves the cursor at (max_width, …)
-                    // (right edge), making available_rect_before_wrap() return a
-                    // near-zero width and collapsing all content to a 1-pixel stripe.
-                    ui.push_id("__cm_viewport", |ui| {
+                    // the cursor is still at (0, 0) — the left edge of a full-width
+                    // row.  Calling it after allocate_space leaves the cursor at
+                    // (max_width, …) (right edge), making available_rect_before_wrap()
+                    // return near-zero width and collapsing all content to a thin strip.
+                    ui.push_id(("__cm_viewport", skip_count), |ui| {
                         // Skip over off-screen content by reserving its vertical space.
                         // Full width is essential: a narrower allocation would leave
                         // the cursor mid-row, misaligning the first visible block.

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -363,7 +363,11 @@ impl CommonMarkViewerInternal {
                         // duplicate newline. Start from the next event instead.
                         let (skip_count, take_count) = if let Some((idx, _, _)) = preceding_split {
                             self.line.should_not_start_newline_forced = false;
-                            (idx + 1, last_event_index - idx)
+                            // last_event_index should always be >= idx because
+                            // split-points are ordered, but guard against stale
+                            // cache or tiny documents producing an underflow.
+                            let take = last_event_index.saturating_sub(idx);
+                            (idx + 1, take)
                         } else {
                             (0, last_event_index)
                         };

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -797,7 +797,7 @@ impl CommonMarkViewerInternal {
     fn render_body_text(
         &self,
         ui: &mut Ui,
-        cache: &CommonMarkCache,
+        cache: &mut CommonMarkCache,
         text: &str,
         src_span: Range<usize>,
     ) {
@@ -841,7 +841,10 @@ impl CommonMarkViewerInternal {
                 } else {
                     self.text_style.to_richtext(ui, slice).background_color(bg)
                 };
-                ui.label(rich);
+                let response = ui.label(rich);
+                if *is_active && cache.take_scroll_to_active_match() {
+                    ui.scroll_to_rect(response.rect, Some(egui::Align::Center));
+                }
             }
             pos = *end;
         }

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -263,20 +263,35 @@ impl Image {
         }
     }
 
-    pub fn end(self, ui: &mut Ui, options: &CommonMarkOptions) {
+    /// Returns the rendered height in points, or `0.0` if the texture is still
+    /// loading. The caller uses this to detect whether split-point heights can
+    /// be trusted.
+    pub fn end(self, ui: &mut Ui, options: &CommonMarkOptions) -> f32 {
+        let Self { uri, alt_text } = self;
         let response = ui.add(
-            egui::Image::from_uri(&self.uri)
+            egui::Image::from_uri(&uri)
                 .fit_to_original_size(1.0)
                 .max_width(options.max_width(ui)),
         );
-
-        if !self.alt_text.is_empty() && options.show_alt_text_on_hover {
+        let height = response.rect.height();
+        if !alt_text.is_empty() && options.show_alt_text_on_hover {
             response.on_hover_ui_at_pointer(|ui| {
-                for alt in self.alt_text {
+                for alt in alt_text {
                     ui.label(alt);
                 }
             });
         }
+        // egui's 24×24 placeholder means height ≥ 1.0 even while Pending, so
+        // query the load state directly rather than relying on height alone.
+        let is_pending = matches!(
+            ui.ctx().try_load_texture(
+                &uri,
+                egui::TextureOptions::default(),
+                egui::load::SizeHint::default(),
+            ),
+            Ok(egui::load::TexturePoll::Pending { .. })
+        );
+        if is_pending { 0.0 } else { height }
     }
 }
 

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -469,8 +469,14 @@ pub struct CommonMarkCache {
     pub pending_scroll_delta: egui::Vec2,
     /// Byte ranges in the source string that should be highlighted as search matches.
     search_ranges: Vec<std::ops::Range<usize>>,
-    /// The active (focused) search match, shown with a distinct highlight colour.
+    /// The active (focused) search match, shown with a distinct highlight color.
     active_search_range: Option<std::ops::Range<usize>>,
+    /// Background color for passive search match highlights. Defaults to `None`,
+    /// which falls back to a dimmed version of the egui selection background color.
+    pub search_match_bg: Option<egui::Color32>,
+    /// Background color for the active (focused) search match highlight. Defaults to
+    /// `None`, which falls back to the egui selection background color.
+    pub active_search_match_bg: Option<egui::Color32>,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -488,6 +494,8 @@ impl Default for CommonMarkCache {
             pending_scroll_delta: egui::Vec2::ZERO,
             search_ranges: Vec::new(),
             active_search_range: None,
+            search_match_bg: None,
+            active_search_match_bg: None,
         }
     }
 }
@@ -633,6 +641,18 @@ impl CommonMarkCache {
     /// The active search match range.
     pub fn active_search_range(&self) -> Option<&std::ops::Range<usize>> {
         self.active_search_range.as_ref()
+    }
+
+    /// Override the background color used for passive search match highlights.
+    /// Pass `None` to restore the default (a dimmed egui selection color).
+    pub fn set_search_match_bg(&mut self, color: Option<egui::Color32>) {
+        self.search_match_bg = color;
+    }
+
+    /// Override the background color used for the active (focused) search match.
+    /// Pass `None` to restore the default (the egui selection color).
+    pub fn set_active_search_match_bg(&mut self, color: Option<egui::Color32>) {
+        self.active_search_match_bg = color;
     }
 
     /// Accumulate a scroll delta for the next `show_scrollable` call.

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -469,8 +469,13 @@ pub struct CommonMarkCache {
     pub pending_scroll_delta: egui::Vec2,
     /// Byte ranges in the source string that should be highlighted as search matches.
     search_ranges: Vec<std::ops::Range<usize>>,
-    /// The active (focused) search match, shown with a distinct highlight color.
+    /// The active (focused) search match, shown with a distinct highlight colour.
     active_search_range: Option<std::ops::Range<usize>>,
+    /// When true, the renderer will scroll the enclosing `ScrollArea` to centre
+    /// the active search match in the viewport on the next frame, then clear
+    /// this flag automatically.
+    scroll_to_active_match: bool,
+    /// Background colour for passive search match highlights.
     /// Background color for passive search match highlights. Defaults to `None`,
     /// which falls back to a dimmed version of the egui selection background color.
     pub search_match_bg: Option<egui::Color32>,
@@ -494,6 +499,7 @@ impl Default for CommonMarkCache {
             pending_scroll_delta: egui::Vec2::ZERO,
             search_ranges: Vec::new(),
             active_search_range: None,
+            scroll_to_active_match: false,
             search_match_bg: None,
             active_search_match_bg: None,
         }
@@ -643,8 +649,21 @@ impl CommonMarkCache {
         self.active_search_range.as_ref()
     }
 
-    /// Override the background color used for passive search match highlights.
-    /// Pass `None` to restore the default (a dimmed egui selection color).
+    /// Request that the renderer scroll the enclosing `ScrollArea` to centre
+    /// the active search match in the viewport on the next frame.
+    /// The flag is cleared automatically once the scroll has been applied.
+    pub fn set_scroll_to_active_match(&mut self, scroll: bool) {
+        self.scroll_to_active_match = scroll;
+    }
+
+    /// Returns whether a scroll-to-active-match was requested, and clears the
+    /// flag. Called internally by the renderer.
+    pub fn take_scroll_to_active_match(&mut self) -> bool {
+        std::mem::take(&mut self.scroll_to_active_match)
+    }
+
+    /// Override the background colour used for passive search match highlights.
+    /// Pass `None` to restore the default (a dimmed egui selection colour).
     pub fn set_search_match_bg(&mut self, color: Option<egui::Color32>) {
         self.search_match_bg = color;
     }

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -36,6 +36,10 @@ pub struct CommonMarkOptions<'f> {
     /// Whether to enable scrolling to headings by their ID.
     /// To give a heading an ID, use the syntax `# Heading {#myheadingid}`. Then links to `#myheadingid` e.g. `[click me!](#myheadingid)` will scroll to that heading.
     pub enable_scroll_to_heading: bool,
+    /// When `true`, `show_scrollable` skips off-screen content each frame.
+    /// When `false` (the default), the full document is rendered and egui
+    /// clips what is off-screen — accurate but slower for very large documents.
+    pub use_viewport_cache: bool,
 }
 
 impl std::fmt::Debug for CommonMarkOptions<'_> {
@@ -58,6 +62,7 @@ impl std::fmt::Debug for CommonMarkOptions<'_> {
             )
             .field("alerts", &self.alerts)
             .field("mutable", &self.mutable)
+            .field("use_viewport_cache", &self.use_viewport_cache)
             .finish()
     }
 }
@@ -80,6 +85,7 @@ impl Default for CommonMarkOptions<'_> {
             math_fn: None,
             html_fn: None,
             enable_scroll_to_heading: false,
+            use_viewport_cache: false,
         }
     }
 }
@@ -458,6 +464,13 @@ pub struct CommonMarkCache {
 
     scroll: HashMap<egui::Id, ScrollableCache>,
     pub(self) has_installed_loaders: bool,
+    /// Keyboard / programmatic scroll delta applied inside the next
+    /// `show_scrollable` call and then cleared.
+    pub pending_scroll_delta: egui::Vec2,
+    /// Byte ranges in the source string that should be highlighted as search matches.
+    search_ranges: Vec<std::ops::Range<usize>>,
+    /// The active (focused) search match, shown with a distinct highlight colour.
+    active_search_range: Option<std::ops::Range<usize>>,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -472,6 +485,9 @@ impl Default for CommonMarkCache {
             scroll: Default::default(),
             scroll_to_id_target: None,
             has_installed_loaders: false,
+            pending_scroll_delta: egui::Vec2::ZERO,
+            search_ranges: Vec::new(),
+            active_search_range: None,
         }
     }
 }
@@ -595,6 +611,34 @@ impl CommonMarkCache {
     /// Raw access to link hooks
     pub fn link_hooks_mut(&mut self) -> &mut HashMap<String, bool> {
         &mut self.link_hooks
+    }
+
+    /// Set byte ranges in the source string to highlight as search matches.
+    /// Ranges must be valid UTF-8 character boundaries.
+    pub fn set_search_ranges(&mut self, ranges: Vec<std::ops::Range<usize>>) {
+        self.search_ranges = ranges;
+    }
+
+    /// Set the active (focused) search match, displayed more prominently.
+    /// Pass `None` to clear.
+    pub fn set_active_search_range(&mut self, range: Option<std::ops::Range<usize>>) {
+        self.active_search_range = range;
+    }
+
+    /// The search ranges currently set for highlighting.
+    pub fn search_ranges(&self) -> &[std::ops::Range<usize>] {
+        &self.search_ranges
+    }
+
+    /// The active search match range.
+    pub fn active_search_range(&self) -> Option<&std::ops::Range<usize>> {
+        self.active_search_range.as_ref()
+    }
+
+    /// Accumulate a scroll delta for the next `show_scrollable` call.
+    /// Positive y scrolls toward the top; negative toward the bottom.
+    pub fn set_scroll_delta(&mut self, delta: egui::Vec2) {
+        self.pending_scroll_delta += delta;
     }
 
     /// Set all link hooks to false

--- a/egui_commonmark_backend/src/pulldown.rs
+++ b/egui_commonmark_backend/src/pulldown.rs
@@ -1,6 +1,7 @@
 use crate::alerts::*;
 use egui::{Pos2, Vec2};
 use pulldown_cmark::Options;
+use std::collections::HashMap;
 use std::ops::Range;
 
 #[derive(Default, Debug)]
@@ -8,6 +9,10 @@ pub struct ScrollableCache {
     pub available_size: Vec2,
     pub page_size: Option<Vec2>,
     pub split_points: Vec<(usize, Pos2, Pos2)>,
+    /// Heading slug → virtual y (content-relative; 0 = document top).
+    /// Populated during the full render; used by the viewport path to
+    /// scroll to headings outside the currently rendered slice.
+    pub heading_y_positions: HashMap<String, f32>,
 }
 
 pub type EventIteratorItem<'e> = (usize, (pulldown_cmark::Event<'e>, Range<usize>));


### PR DESCRIPTION
Prerequisite: #98.

This PR adds further enhancements over and above PR 98:

1. Search-match highlighting. This works in both regular and viewport-caching modes. It is currently not implemented for text in code blocks.
2. Further enhancements to the restored `scroll` example: a demonstration of keyboard scrolling shortcuts, and a toggle to allow the example to be run with caching disabled for comparison.
3. 14 small unit tests of the most complex virtualisation logic used to enable viewport caching.

