### PR TITLE
Fix text overflow after wide table (issue #97)

### DIFF
--- a/egui_commonmark/examples/book.rs
+++ b/egui_commonmark/examples/book.rs
@@ -130,6 +130,10 @@ fn main() -> eframe::Result {
                         content: include_str!("markdown/tables.md").to_owned(),
                     },
                     Page {
+                        name: "Wide Tables".to_owned(),
+                        content: include_str!("markdown/wide_table.md").to_owned(),
+                    },
+                    Page {
                         name: "Embedded Image".to_owned(),
                         content: include_str!("markdown/embedded_image.md").to_owned(),
                     },

--- a/egui_commonmark/examples/markdown/wide_table.md
+++ b/egui_commonmark/examples/markdown/wide_table.md
@@ -1,0 +1,13 @@
+# Wide Tables
+
+Wide tables scroll horizontally within the document width. Text wrapping before and after the table is unaffected.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat:
+
+| Lorem | Ipsum | Dolor |
+|---|---|---|
+| Consectetur | Excepteur sint occaecat | `Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.` |
+| Consectetur | Excepteur sint occaecat | `Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.` |
+| Consectetur | Excepteur sint occaecat | `Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.` |
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat:

--- a/egui_commonmark/examples/wide_table.rs
+++ b/egui_commonmark/examples/wide_table.rs
@@ -1,0 +1,56 @@
+//! Make sure to run this example from the repo directory and not the example
+//! directory. To see all the features in full effect, run this example with
+//! `cargo r --features better_syntax_highlighting,svg,fetch`
+//! Add `light` or `dark` to the end of the command to specify theme. Default
+//! is system theme. `cargo r --features better_syntax_highlighting,svg,fetch -- dark`
+//!
+//! Demonstrates that wide tables scroll horizontally without affecting text
+//! wrapping in the surrounding document.
+
+use eframe::egui;
+use egui_commonmark::*;
+
+struct App {
+    cache: CommonMarkCache,
+}
+
+impl eframe::App for App {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let text = include_str!("markdown/wide_table.md");
+        egui::CentralPanel::default().show(ui, |ui| {
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                CommonMarkViewer::new()
+                    .max_image_width(Some(512))
+                    .show(ui, &mut self.cache, text);
+            });
+        });
+    }
+}
+
+fn main() -> eframe::Result {
+    let mut args = std::env::args();
+    args.next();
+
+    eframe::run_native(
+        "Markdown viewer",
+        eframe::NativeOptions::default(),
+        Box::new(move |cc| {
+            if let Some(theme) = args.next() {
+                if theme == "light" {
+                    cc.egui_ctx.set_theme(egui::Theme::Light);
+                } else if theme == "dark" {
+                    cc.egui_ctx.set_theme(egui::Theme::Dark);
+                }
+            }
+
+            cc.egui_ctx.global_style_mut(|style| {
+                // Show the url of a hyperlink on hover
+                style.url_in_tooltip = true;
+            });
+
+            Ok(Box::new(App {
+                cache: CommonMarkCache::default(),
+            }))
+        }),
+    )
+}

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -655,43 +655,54 @@ impl CommonMarkViewerInternal {
             egui::Frame::group(ui.style()).show(ui, |ui| {
                 let Table { header, rows } = parse_table(events);
 
-                egui::Grid::new(id).striped(true).show(ui, |ui| {
-                    for col in header {
-                        ui.horizontal(|ui| {
-                            for (e, src_span) in col {
-                                let tmp_start =
-                                    std::mem::replace(&mut self.line.should_start_newline, false);
-                                let tmp_end =
-                                    std::mem::replace(&mut self.line.should_end_newline, false);
-                                self.event(ui, e, src_span, cache, options, max_width);
-                                self.line.should_start_newline = tmp_start;
-                                self.line.should_end_newline = tmp_end;
+                ui.spacing_mut().scroll.content_margin.bottom = ui.spacing().scroll.bar_width as i8;
+                egui::ScrollArea::horizontal()
+                    .id_salt(id.with("_hscroll"))
+                    .show(ui, |ui| {
+                        egui::Grid::new(id).striped(true).show(ui, |ui| {
+                            for col in header {
+                                ui.horizontal(|ui| {
+                                    for (e, src_span) in col {
+                                        let tmp_start = std::mem::replace(
+                                            &mut self.line.should_start_newline,
+                                            false,
+                                        );
+                                        let tmp_end = std::mem::replace(
+                                            &mut self.line.should_end_newline,
+                                            false,
+                                        );
+                                        self.event(ui, e, src_span, cache, options, max_width);
+                                        self.line.should_start_newline = tmp_start;
+                                        self.line.should_end_newline = tmp_end;
+                                    }
+                                });
+                            }
+
+                            ui.end_row();
+
+                            for row in rows {
+                                for col in row {
+                                    ui.horizontal(|ui| {
+                                        for (e, src_span) in col {
+                                            let tmp_start = std::mem::replace(
+                                                &mut self.line.should_start_newline,
+                                                false,
+                                            );
+                                            let tmp_end = std::mem::replace(
+                                                &mut self.line.should_end_newline,
+                                                false,
+                                            );
+                                            self.event(ui, e, src_span, cache, options, max_width);
+                                            self.line.should_start_newline = tmp_start;
+                                            self.line.should_end_newline = tmp_end;
+                                        }
+                                    });
+                                }
+
+                                ui.end_row();
                             }
                         });
-                    }
-
-                    ui.end_row();
-
-                    for row in rows {
-                        for col in row {
-                            ui.horizontal(|ui| {
-                                for (e, src_span) in col {
-                                    let tmp_start = std::mem::replace(
-                                        &mut self.line.should_start_newline,
-                                        false,
-                                    );
-                                    let tmp_end =
-                                        std::mem::replace(&mut self.line.should_end_newline, false);
-                                    self.event(ui, e, src_span, cache, options, max_width);
-                                    self.line.should_start_newline = tmp_start;
-                                    self.line.should_end_newline = tmp_end;
-                                }
-                            });
-                        }
-
-                        ui.end_row();
-                    }
-                });
+                    });
             });
 
             self.is_table = false;


### PR DESCRIPTION
Fixes #97.

When a table is wider than the available width, egui expands `max_rect` to match the actual content width:

```
allocate_ui_with_layout → scope_dyn → advance_cursor_after_rect(child_ui.min_rect())
    → advance_after_rects → Region::expand_to_include_rect: self.max_rect |= rect
```

This leaves `max_rect` wider than the window for the rest of the layout pass, so that text following the table wraps at the table width instead of the window edge, causing each line of text to appear truncated at the right-hand viewport margin unless the window is maximised.

Fix: wrap the table `Grid` in a `ScrollArea::horizontal()`, which bounds the grid layout within its own child UI and prevents it from widening `max_rect`. Each scroll area gets a per-table `id_salt` to avoid ID collisions when multiple tables appear in the same document.

This fix was awaiting `egui` PR #8275 to fix `egui`'s scroll request handling to avoid having the horizontal `ScrollArea`s invalidly consuming vertical scroll requests intended for the main document. That PR has since been incorporated into `egui 0.36.0`.

Also adds a `wide_table` example and a corresponding "Wide Tables" page to `book.rs`.
