### PR TITLE
Add text search capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 **/target
 egui_commonmark_macros/wip/
+New PR for feat_scroll-delta.md
+Search_match_AI_summary.md
+Search_highlighting_for_code_blocks_in_egui_commonmark.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,2 @@
 **/target
 egui_commonmark_macros/wip/
-egui_commonmark/examples/search_temp.rs
-Search_Match_Scrolling_Without_Viewport_Cache.md
-*.folded
-*.profraw
-*.DS_Store
-Search_match_viewport_sync_without_cache.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 egui_commonmark_macros/wip/
 egui_commonmark/examples/search_temp.rs
 Search_Match_Scrolling_Without_Viewport_Cache.md
+*.folded
+*.profraw
+*.DS_Store
+Search_match_viewport_sync_without_cache.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 **/target
 egui_commonmark_macros/wip/
-New PR for feat_scroll-delta.md
-Search_match_AI_summary.md
-Search_highlighting_for_code_blocks_in_egui_commonmark.md
+egui_commonmark/examples/search_temp.rs
+Search_Match_Scrolling_Without_Viewport_Cache.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 - `viewport_cache` to disable or enable viewport cache for `show_scrollable`
   ([#101](https://github.com/lampsitter/egui_commonmark/pull/101) by [@durbanlegend](https://github.com/durbanlegend))
 - Search-match highlighting via `CommonMarkCache::set_search_ranges` and
-  `set_active_search_range`. Matches are highlighted inside body text *and*
-  fenced/indented code blocks (including with syntax highlighting enabled).
+  `set_active_search_range`. Matches are highlighted inside body text, link
+  text and fenced/indented code blocks (including with syntax highlighting enabled).
+- Search and scroll support built into `CommonMarkCache`
   Call `CommonMarkCache::scroll_to_active_search_match` to scroll (and
   center) the currently active match into view, including when using
   `show_scrollable`'s viewport cache.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # egui_commonmark changelog
 
+## Unreleased
+
+### Added
+
+- Search-match highlighting via `CommonMarkCache::set_search_ranges` and
+  `set_active_search_range`. Matches are highlighted inside body text *and*
+  fenced/indented code blocks (including with syntax highlighting enabled).
+  Call `CommonMarkCache::scroll_to_active_search_match` to scroll (and
+  center) the currently active match into view, including when using
+  `show_scrollable`'s viewport cache.
+
 ## 0.25.0 - 2026-08-05
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,10 +626,12 @@ dependencies = [
 name = "egui_commonmark_backend"
 version = "0.25.0"
 dependencies = [
+ "bitflags 2.13.1",
  "data-url",
  "egui",
  "egui_extras",
  "pulldown-cmark",
+ "regex",
  "syntect",
 ]
 
@@ -2306,6 +2308,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "document-features",
  "eframe",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "data-url",
  "egui",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_macros"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "document-features",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,9 @@ pulldown-cmark = { version = "0.13", default-features = false }
 # eframe = { path = "../../egui/crates/eframe" }
 # egui = { path = "../../egui/crates/egui" }
 # egui_extras = { path = "../../egui/crates/egui_extras" }
+
+
+# Allow performance-critical examples to approach real-world responsiveness
+[profile.dev]
+opt-level = 3     # Apply maximum performance optimizations
+debug = true

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -21,24 +21,50 @@ struct App {
 }
 
 impl App {
+    /// Recomputes `search_matches` from the *rendered* text only (via
+    /// pulldown-cmark's `Text`/`Code` events), so link destinations,
+    /// heading `{#id}` attribute syntax, and other non-visible markdown
+    /// syntax are never matched (a naive substring search over the raw
+    /// source would, for example, double-count "500" in
+    /// `[Section 500](#section-500)`: once in the visible text, once in the
+    /// URL).
+    ///
+    /// Does not move the active match or scroll anywhere: navigation only
+    /// happens once the user explicitly commits via Next/Previous/Enter
+    /// (see `go_to_match`), so that live highlights appear as you type
+    /// without the view jumping around underneath you.
     fn update_search_matches(&mut self) {
         self.search_matches.clear();
         if !self.search_query.is_empty() {
             let query = self.search_query.to_lowercase();
-            let haystack = self.content.to_lowercase();
-            let mut start = 0;
-            while let Some(pos) = haystack[start..].find(&query) {
-                let match_start = start + pos;
-                let match_end = match_start + query.len();
-                self.search_matches.push(match_start..match_end);
-                start = match_end;
+            // Mirror the options CommonMarkViewer itself parses with,
+            // including heading attributes since `enable_scroll_to_heading`
+            // is set below (otherwise `{#section-500}` would remain in the
+            // heading's Text event and get matched too).
+            let options = pulldown_cmark::Options::ENABLE_STRIKETHROUGH
+                | pulldown_cmark::Options::ENABLE_TASKLISTS
+                | pulldown_cmark::Options::ENABLE_TABLES
+                | pulldown_cmark::Options::ENABLE_FOOTNOTES
+                | pulldown_cmark::Options::ENABLE_HEADING_ATTRIBUTES;
+            let parser = pulldown_cmark::Parser::new_ext(&self.content, options).into_offset_iter();
+            for (event, range) in parser {
+                let text = match event {
+                    pulldown_cmark::Event::Text(text) | pulldown_cmark::Event::Code(text) => text,
+                    _ => continue,
+                };
+                let haystack = text.to_lowercase();
+                let mut start = 0;
+                while let Some(pos) = haystack[start..].find(&query) {
+                    let match_start = range.start + start + pos;
+                    let match_end = match_start + query.len();
+                    self.search_matches.push(match_start..match_end);
+                    start += pos + query.len();
+                }
             }
         }
-        self.active_match = if self.search_matches.is_empty() {
-            None
-        } else {
-            Some(0)
-        };
+        // Leave the active match unset; go_to_match() picks a starting point
+        // (first or last match) the first time the user navigates.
+        self.active_match = None;
         self.cache.set_search_ranges(self.search_matches.clone());
         self.sync_active_match();
     }
@@ -56,8 +82,13 @@ impl App {
             return;
         }
         let len = self.search_matches.len() as isize;
-        let current = self.active_match.map(|i| i as isize).unwrap_or(0);
-        let next = (current + delta).rem_euclid(len);
+        let next = match self.active_match {
+            Some(i) => (i as isize + delta).rem_euclid(len),
+            // First navigation after a fresh search: start at the first
+            // match for Next, the last one for Previous.
+            None if delta >= 0 => 0,
+            None => len - 1,
+        };
         self.active_match = Some(next as usize);
         self.sync_active_match();
         self.cache.scroll_to_active_search_match();

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -1,7 +1,12 @@
 //! Make sure to run this example from the repo directory and not the example
 //! directory. Run with:
-//! `cargo r --example scroll --features better_syntax_highlighting,svg`
-//! Add `light` or `dark` to set the theme.
+//! `cargo r --example scroll --features better_syntax_highlighting,svg [light|dark]`
+//! Run with `CACHE=false` to disable viewport caching for comparison.
+//!
+//! Keyboard shortcuts (when no text field has focus):
+//! Up/Down arrows scroll one line; Page Up/Down scroll one page;
+//! Home/End (or Cmd+Up/Down on macOS) jump to the top or bottom.
+use std::env;
 
 use eframe::egui;
 use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
@@ -9,22 +14,73 @@ use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
 struct App {
     cache: CommonMarkCache,
     content: String,
+    viewport_cache: bool,
 }
 
 impl eframe::App for App {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        ui.set_min_height(512.0);
+
         egui::CentralPanel::default().show(ui, |ui| {
+            ui.style_mut().spacing.scroll = egui::style::ScrollStyle::thin();
+
+            let (
+                scroll_line_up,
+                scroll_line_down,
+                scroll_page_up,
+                scroll_page_down,
+                scroll_doc_top,
+                scroll_doc_bottom,
+            ) = ui.ctx().input(|i| {
+                use egui::Key;
+                (
+                    !i.modifiers.command && i.key_pressed(Key::ArrowUp),
+                    !i.modifiers.command && i.key_pressed(Key::ArrowDown),
+                    i.key_pressed(Key::PageUp),
+                    i.key_pressed(Key::PageDown),
+                    i.key_pressed(Key::Home)
+                        || (i.modifiers.command && i.key_pressed(Key::ArrowUp)),
+                    i.key_pressed(Key::End)
+                        || (i.modifiers.command && i.key_pressed(Key::ArrowDown)),
+                )
+            });
+
+            // Only act on scroll keys when no text field has focus.
+            if !ui.ctx().egui_wants_keyboard_input() {
+                let line_h = ui.text_style_height(&egui::TextStyle::Body);
+                let page_h = ui.available_height();
+                if scroll_line_up {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, line_h));
+                } else if scroll_line_down {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, -line_h));
+                } else if scroll_page_up {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, page_h));
+                } else if scroll_page_down {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, -page_h));
+                } else if scroll_doc_top {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, f32::MAX / 2.0));
+                } else if scroll_doc_bottom {
+                    self.cache
+                        .set_scroll_delta(egui::vec2(0.0, -f32::MAX / 2.0));
+                }
+            }
+
             CommonMarkViewer::new()
                 .max_image_width(Some(512))
                 .enable_scroll_to_heading(true)
+                .viewport_cache(self.viewport_cache)
                 .show_scrollable("scroll_example", ui, &mut self.cache, &self.content);
         });
     }
 }
 
 fn main() -> eframe::Result {
-    let mut args = std::env::args();
+    let mut args = env::args();
     args.next();
+
+    let viewport_cache = env::var("CACHE")
+        .map(|v| v.to_lowercase() != "false" && v != "0")
+        .unwrap_or(true);
 
     let content = build_document();
     eprintln!("Document size: {} bytes", content.len());
@@ -43,6 +99,7 @@ fn main() -> eframe::Result {
             Ok(Box::new(App {
                 cache: CommonMarkCache::default(),
                 content,
+                viewport_cache,
             }))
         }),
     )
@@ -57,28 +114,33 @@ fn build_document() -> String {
          This document demonstrates `show_scrollable`: only the visible slice is \
          rendered each frame, so scrolling stays fast regardless of document length. \
          The TOC link above jumps to section 500, far outside the initial viewport, \
-         to demonstrate that heading navigation works across the full document.\n\
+         to demonstrate that heading navigation works across the full document.\
+         \n\
+         Keyboard shortcuts: Up/Down arrows scroll one line; Page Up/Down scroll \
+         one page; Home/End (or Cmd+Up/Down on macOS) jump to the top or bottom.\
          \n",
     );
 
     for i in 1..=1024_usize {
         let id = if i == 500 { " {#section-500}" } else { "" };
         text += &format!(
-            "\n## Section {i}{id}\n\
-             \n\
-             This is section {i}. Each section contains a short code block and an image.\n\
-             \n\
-             ```rs\n\
-             let mut vec = Vec::new();\n\
-             vec.push({i});\n\
-             ```\n\
-             \n\
-             * Make a sandwich\n\
-             * Bake a cake\n\
-             * Conquer the world\n\
-             \n\
-             ![Ferris the Rust mascot](egui_commonmark/examples/cuddlyferris.png)\n\
-             \n"
+            r#"
+## Section {i}{id}
+
+This is section {i}. Each section contains a short code block and an image.
+
+```rs
+let mut vec = Vec::new();
+vec.push({i});
+```
+
+* Make a sandwich
+* Bake a cake
+* Conquer the world
+
+![Ferris the Rust mascot](egui_commonmark/examples/cuddlyferris.png)
+
+"#
         );
     }
     text

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -11,6 +11,8 @@ use std::env;
 use eframe::egui;
 use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
 
+const EGUI_SOURCE_ID: &'static str = "scroll_example";
+
 struct App {
     cache: CommonMarkCache,
     content: String,
@@ -56,8 +58,10 @@ impl App {
             .active_match
             .and_then(|i| self.search_matches.get(i))
             .map(|r| r.start)
-            .or_else(|| self.cache.viewport_start_byte_offset("scroll_example"))
+            .or_else(|| self.cache.viewport_start_byte_offset(EGUI_SOURCE_ID))
             .unwrap_or(0);
+        dbg!(&anchor);
+        dbg!(&self.last_viewport_offset);
 
         self.search_matches.clear();
         if !self.search_query.is_empty() {
@@ -242,7 +246,7 @@ impl eframe::App for App {
                 .max_image_width(Some(512))
                 .enable_scroll_to_heading(true)
                 .viewport_cache(self.viewport_cache)
-                .show_scrollable("scroll_example", ui, &mut self.cache, &self.content);
+                .show_scrollable(EGUI_SOURCE_ID, ui, &mut self.cache, &self.content);
 
             // After show_scrollable the viewer has applied any pending scroll
             // delta and updated the byte-offset tracker.  Sync active_match
@@ -252,8 +256,9 @@ impl eframe::App for App {
             // settle to the correct match once the animation completes.
             let current_offset = self
                 .cache
-                .viewport_start_byte_offset("scroll_example")
+                .viewport_start_byte_offset(EGUI_SOURCE_ID)
                 .unwrap_or(0);
+            let current_scroll_y = scroll_output.state.offset.y;
 
             if !self.search_matches.is_empty()
                 && self.search_scroll_protection == 0

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -11,12 +11,11 @@ use std::env;
 use eframe::egui;
 use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
 
-const EGUI_SOURCE_ID: &'static str = "scroll_example";
-
 struct App {
     cache: CommonMarkCache,
-    content: String,
+    egui_source_id: String,
     viewport_cache: bool,
+    content: String,
 }
 
 impl App {}
@@ -31,8 +30,7 @@ impl eframe::App for App {
                 let response = ui.text_edit_singleline(&mut self.cache.search_query);
                 if response.changed() {
                     self.cache
-                        .update_search_matches(EGUI_SOURCE_ID, &self.content);
-                    // self.update_search_matches();
+                        .update_search_matches(&self.egui_source_id, &self.content);
                 }
                 // Re-request focus so that repeated Enter presses keep working without having to
                 // click back into the box each time.
@@ -63,16 +61,23 @@ impl eframe::App for App {
         egui::CentralPanel::default().show(ui, |ui| {
             ui.style_mut().spacing.scroll = egui::style::ScrollStyle::thin();
 
+            // Handle any keyboard scrolling requests
             let user_scrolled = self.cache.handle_keyboard_scrolling(ui);
 
+            // `show_scrollable` will automatically scroll by any accumulated scroll amount
+            // before rendering
             CommonMarkViewer::new()
                 .max_image_width(Some(512))
                 .enable_scroll_to_heading(true)
                 .viewport_cache(self.viewport_cache)
-                .show_scrollable(EGUI_SOURCE_ID, ui, &mut self.cache, &self.content);
+                .show_scrollable(&self.egui_source_id, ui, &mut self.cache, &self.content);
 
+            // Use the scrollable sync method to sync any search to the current viewport so
+            // that Next/Previous will continue from here instead of from its previous location.
+            // Unlike the regular `sync_active_match` method, this also supports new searches
+            // because it is confined to a range of known split points from the last full render.
             self.cache.sync_scrollable_active_match(
-                EGUI_SOURCE_ID,
+                &self.egui_source_id,
                 self.viewport_cache,
                 user_scrolled,
             );
@@ -104,8 +109,9 @@ fn main() -> eframe::Result {
             }
             Ok(Box::new(App {
                 cache: CommonMarkCache::default(),
-                content,
+                egui_source_id: String::from("scroll_example"),
                 viewport_cache,
+                content,
             }))
         }),
     )

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -1,0 +1,85 @@
+//! Make sure to run this example from the repo directory and not the example
+//! directory. Run with:
+//! `cargo r --example scroll --features better_syntax_highlighting,svg`
+//! Add `light` or `dark` to set the theme.
+
+use eframe::egui;
+use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
+
+struct App {
+    cache: CommonMarkCache,
+    content: String,
+}
+
+impl eframe::App for App {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ui, |ui| {
+            CommonMarkViewer::new()
+                .max_image_width(Some(512))
+                .enable_scroll_to_heading(true)
+                .show_scrollable("scroll_example", ui, &mut self.cache, &self.content);
+        });
+    }
+}
+
+fn main() -> eframe::Result {
+    let mut args = std::env::args();
+    args.next();
+
+    let content = build_document();
+    eprintln!("Document size: {} bytes", content.len());
+
+    eframe::run_native(
+        "Markdown scroll example",
+        eframe::NativeOptions::default(),
+        Box::new(move |cc| {
+            if let Some(theme) = args.next() {
+                if theme == "light" {
+                    cc.egui_ctx.set_theme(egui::Theme::Light);
+                } else if theme == "dark" {
+                    cc.egui_ctx.set_theme(egui::Theme::Dark);
+                }
+            }
+            Ok(Box::new(App {
+                cache: CommonMarkCache::default(),
+                content,
+            }))
+        }),
+    )
+}
+
+fn build_document() -> String {
+    let mut text = String::from(
+        "# Markdown Scroll Example\n\
+         \n\
+         Jump to: [Section 500](#section-500)\n\
+         \n\
+         This document demonstrates `show_scrollable`: only the visible slice is \
+         rendered each frame, so scrolling stays fast regardless of document length. \
+         The TOC link above jumps to section 500, far outside the initial viewport, \
+         to demonstrate that heading navigation works across the full document.\n\
+         \n",
+    );
+
+    for i in 1..=1024_usize {
+        let id = if i == 500 { " {#section-500}" } else { "" };
+        text += &format!(
+            "\n## Section {i}{id}\n\
+             \n\
+             This is section {i}. Each section contains a short code block and an image.\n\
+             \n\
+             ```rs\n\
+             let mut vec = Vec::new();\n\
+             vec.push({i});\n\
+             ```\n\
+             \n\
+             * Make a sandwich\n\
+             * Bake a cake\n\
+             * Conquer the world\n\
+             \n\
+             ![Ferris the Rust mascot](egui_commonmark/examples/cuddlyferris.png)\n\
+             \n"
+        );
+    }
+    text
+}

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -15,11 +15,87 @@ struct App {
     cache: CommonMarkCache,
     content: String,
     viewport_cache: bool,
+    search_query: String,
+    search_matches: Vec<std::ops::Range<usize>>,
+    active_match: Option<usize>,
+}
+
+impl App {
+    fn update_search_matches(&mut self) {
+        self.search_matches.clear();
+        if !self.search_query.is_empty() {
+            let query = self.search_query.to_lowercase();
+            let haystack = self.content.to_lowercase();
+            let mut start = 0;
+            while let Some(pos) = haystack[start..].find(&query) {
+                let match_start = start + pos;
+                let match_end = match_start + query.len();
+                self.search_matches.push(match_start..match_end);
+                start = match_end;
+            }
+        }
+        self.active_match = if self.search_matches.is_empty() {
+            None
+        } else {
+            Some(0)
+        };
+        self.cache.set_search_ranges(self.search_matches.clone());
+        self.sync_active_match();
+    }
+
+    fn sync_active_match(&mut self) {
+        self.cache.set_active_search_range(
+            self.active_match
+                .and_then(|i| self.search_matches.get(i))
+                .cloned(),
+        );
+    }
+
+    fn go_to_match(&mut self, delta: isize) {
+        if self.search_matches.is_empty() {
+            return;
+        }
+        let len = self.search_matches.len() as isize;
+        let current = self.active_match.map(|i| i as isize).unwrap_or(0);
+        let next = (current + delta).rem_euclid(len);
+        self.active_match = Some(next as usize);
+        self.sync_active_match();
+        self.cache.scroll_to_active_search_match();
+    }
 }
 
 impl eframe::App for App {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         ui.set_min_height(512.0);
+
+        egui::Panel::top("search_bar").show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Search:");
+                let response = ui.text_edit_singleline(&mut self.search_query);
+                if response.changed() {
+                    self.update_search_matches();
+                }
+                let enter_pressed =
+                    response.lost_focus() && ui.ctx().input(|i| i.key_pressed(egui::Key::Enter));
+
+                let match_count = self.search_matches.len();
+                ui.label(match self.active_match {
+                    Some(i) if match_count > 0 => format!("{}/{match_count}", i + 1),
+                    _ => format!("0/{match_count}"),
+                });
+
+                if ui.button("Previous").clicked()
+                    || (enter_pressed && ui.input(|i| i.modifiers.shift))
+                {
+                    self.go_to_match(-1);
+                }
+                if ui.button("Next").clicked()
+                    || (enter_pressed && !ui.input(|i| i.modifiers.shift))
+                {
+                    self.go_to_match(1);
+                }
+            });
+        });
 
         egui::CentralPanel::default().show(ui, |ui| {
             ui.style_mut().spacing.scroll = egui::style::ScrollStyle::thin();
@@ -100,6 +176,9 @@ fn main() -> eframe::Result {
                 cache: CommonMarkCache::default(),
                 content,
                 viewport_cache,
+                search_query: String::new(),
+                search_matches: Vec::new(),
+                active_match: None,
             }))
         }),
     )

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -18,6 +18,14 @@ struct App {
     search_query: String,
     search_matches: Vec<std::ops::Range<usize>>,
     active_match: Option<usize>,
+    /// Counts down after search-initiated scrolls (Next / Previous / query
+    /// change) to block viewport-driven active_match updates while the
+    /// scroll-to-match animation is still in progress.  User scroll input
+    /// immediately clears this to zero so the user always wins.
+    search_scroll_protection: u32,
+    /// Byte offset reported by the viewer at the end of the last frame;
+    /// used to detect viewport movement without relying on input events.
+    last_viewport_offset: usize,
 }
 
 impl App {
@@ -95,6 +103,10 @@ impl App {
         self.active_match = Some(nearest);
         self.sync_active_match();
         self.cache.scroll_to_active_search_match();
+        // Suppress viewport-sync for ~30 frames so the animation toward the
+        // new match is not immediately overridden by the centering drift
+        // (viewport start lands before the active match when centred on screen).
+        self.search_scroll_protection = 30;
     }
 
     fn sync_active_match(&mut self) {
@@ -120,6 +132,7 @@ impl App {
         self.active_match = Some(next as usize);
         self.sync_active_match();
         self.cache.scroll_to_active_search_match();
+        self.search_scroll_protection = 30;
     }
 }
 
@@ -208,20 +221,22 @@ impl eframe::App for App {
                 }
             }
 
-            // Detect genuine user-initiated scroll this frame (mouse wheel /
-            // trackpad OR keyboard scroll keys).  Programmatic search scrolls
-            // never produce these input events, so no suppress flag is needed.
-            let user_scrolled = !self.search_matches.is_empty() && {
-                let has_mouse_scroll = ui.input(|i| i.is_scrolling());
-                let has_kb_scroll = !ui.ctx().egui_wants_keyboard_input()
+            // Any explicit user scroll input immediately cancels protection so
+            // the user's scroll position always wins over search animation.
+            let user_scroll_input = {
+                let has_mouse = ui.input(|i| i.is_scrolling());
+                let has_kb = !ui.ctx().egui_wants_keyboard_input()
                     && (scroll_line_up
                         || scroll_line_down
                         || scroll_page_up
                         || scroll_page_down
                         || scroll_doc_top
                         || scroll_doc_bottom);
-                has_mouse_scroll || has_kb_scroll
+                has_mouse || has_kb
             };
+            if user_scroll_input {
+                self.search_scroll_protection = 0;
+            }
 
             CommonMarkViewer::new()
                 .max_image_width(Some(512))
@@ -229,26 +244,40 @@ impl eframe::App for App {
                 .viewport_cache(self.viewport_cache)
                 .show_scrollable("scroll_example", ui, &mut self.cache, &self.content);
 
-            // After the frame has rendered (scroll deltas applied), sync
-            // active_match to the nearest match at the new viewport position.
-            // Only do this for user-driven scrolls — search-initiated scrolls
-            // must not reset the match we just navigated to.
-            if user_scrolled {
-                let cursor = self
-                    .cache
-                    .viewport_start_byte_offset("scroll_example")
-                    .unwrap_or(0);
+            // After show_scrollable the viewer has applied any pending scroll
+            // delta and updated the byte-offset tracker.  Sync active_match
+            // whenever the viewport byte offset actually changed AND no search
+            // scroll is still animating.  This fires on every animation frame
+            // (not just the key-press frame), so even large PageDown jumps
+            // settle to the correct match once the animation completes.
+            let current_offset = self
+                .cache
+                .viewport_start_byte_offset("scroll_example")
+                .unwrap_or(0);
+
+            if !self.search_matches.is_empty()
+                && self.search_scroll_protection == 0
+                && current_offset != self.last_viewport_offset
+            {
+                let len = self.search_matches.len();
                 let nearest = self
                     .search_matches
                     .iter()
-                    .position(|r| r.start >= cursor)
-                    .unwrap_or(0);
+                    .position(|r| r.start >= current_offset)
+                    // If the viewport is past the last match, show the last
+                    // match rather than wrapping back to the first.
+                    .unwrap_or(len - 1);
                 if self.active_match != Some(nearest) {
                     self.active_match = Some(nearest);
                     self.sync_active_match();
                     // Do NOT call scroll_to_active_search_match here: the
                     // viewport is already where the user put it.
                 }
+            }
+
+            self.last_viewport_offset = current_offset;
+            if self.search_scroll_protection > 0 {
+                self.search_scroll_protection -= 1;
             }
         });
     }
@@ -283,6 +312,8 @@ fn main() -> eframe::Result {
                 search_query: String::new(),
                 search_matches: Vec::new(),
                 active_match: None,
+                search_scroll_protection: 0,
+                last_viewport_offset: 0,
             }))
         }),
     )

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -34,11 +34,7 @@ impl eframe::App for App {
                         .update_search_matches(EGUI_SOURCE_ID, &self.content);
                     // self.update_search_matches();
                 }
-                // Checked unconditionally (not gated on the text edit still
-                // having focus): a single-line TextEdit surrenders focus the
-                // moment Enter is pressed, so `response.has_focus()` would
-                // already be false here. We re-request focus below so that
-                // repeated Enter presses keep working without having to
+                // Re-request focus so that repeated Enter presses keep working without having to
                 // click back into the box each time.
                 let enter_pressed = ui.input(|i| i.key_pressed(egui::Key::Enter));
                 if enter_pressed {

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -60,8 +60,6 @@ impl App {
             .map(|r| r.start)
             .or_else(|| self.cache.viewport_start_byte_offset(EGUI_SOURCE_ID))
             .unwrap_or(0);
-        dbg!(&anchor);
-        dbg!(&self.last_viewport_offset);
 
         self.search_matches.clear();
         if !self.search_query.is_empty() {
@@ -258,20 +256,29 @@ impl eframe::App for App {
                 .cache
                 .viewport_start_byte_offset(EGUI_SOURCE_ID)
                 .unwrap_or(0);
-            let current_scroll_y = scroll_output.state.offset.y;
 
             if !self.search_matches.is_empty()
                 && self.search_scroll_protection == 0
                 && current_offset != self.last_viewport_offset
             {
                 let len = self.search_matches.len();
-                let nearest = self
+                // This works:
+                // let nearest = self
+                //     .search_matches
+                //     .iter()
+                //     .rposition(|r| r.start < current_offset)
+                //     // If the viewport is past the last match, show the last
+                //     // match rather than wrapping back to the first.
+                //     .unwrap_or(len - 1);
+                // Performance option:
+                let idx = self
                     .search_matches
-                    .iter()
-                    .position(|r| r.start >= current_offset)
-                    // If the viewport is past the last match, show the last
-                    // match rather than wrapping back to the first.
-                    .unwrap_or(len - 1);
+                    .partition_point(|r| r.start < current_offset);
+                let nearest = if idx > 0 {
+                    idx - 1
+                } else {
+                    len.saturating_sub(1)
+                };
                 if self.active_match != Some(nearest) {
                     self.active_match = Some(nearest);
                     self.sync_active_match();

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -17,126 +17,9 @@ struct App {
     cache: CommonMarkCache,
     content: String,
     viewport_cache: bool,
-    search_query: String,
-    search_matches: Vec<std::ops::Range<usize>>,
-    active_match: Option<usize>,
-    /// Counts down after search-initiated scrolls (Next / Previous / query
-    /// change) to block viewport-driven active_match updates while the
-    /// scroll-to-match animation is still in progress.  User scroll input
-    /// immediately clears this to zero so the user always wins.
-    search_scroll_protection: u32,
-    /// Byte offset reported by the viewer at the end of the last frame;
-    /// used to detect viewport movement without relying on input events.
-    last_viewport_offset: usize,
 }
 
-impl App {
-    /// Recomputes `search_matches` from the *rendered* text only (via
-    /// pulldown-cmark's `Text`/`Code` events), so link destinations,
-    /// heading `{#id}` attribute syntax, and other non-visible markdown
-    /// syntax are never matched (a naive substring search over the raw
-    /// source would, for example, double-count "500" in
-    /// `[Section 500](#section-500)`: once in the visible text, once in the
-    /// URL).
-    ///
-    /// Recomputes `search_matches` on every keystroke and immediately
-    /// advances to the nearest match at or after wherever the user is
-    /// currently scrolled to (wrapping to the first match if there is none
-    /// after that point), mirroring how a normal "find in page" behaves.
-    /// Recomputation and the resulting scroll are both cheap (see
-    /// `CommonMarkCache::scroll_to_active_search_match`'s docs: this never
-    /// forces a full document re-render), so this stays responsive even for
-    /// this fairly large (~275 KB) document.
-    fn update_search_matches(&mut self) {
-        // Anchor to the byte position of the currently active match so that
-        // adding/removing characters from the query stays on the same spot.
-        // Fall back to the viewport position for a fresh (no active match)
-        // search.  Using viewport_start here on a query change would jump
-        // backwards whenever the viewport centre is a couple of sections
-        // before the active match (i.e. the match is centred on screen).
-        let anchor = self
-            .active_match
-            .and_then(|i| self.search_matches.get(i))
-            .map(|r| r.start)
-            .or_else(|| self.cache.viewport_start_byte_offset(EGUI_SOURCE_ID))
-            .unwrap_or(0);
-
-        self.search_matches.clear();
-        if !self.search_query.is_empty() {
-            let query = self.search_query.to_lowercase();
-            // Mirror the options CommonMarkViewer itself parses with,
-            // including heading attributes since `enable_scroll_to_heading`
-            // is set below (otherwise `{#section-500}` would remain in the
-            // heading's Text event and get matched too).
-            let options = pulldown_cmark::Options::ENABLE_STRIKETHROUGH
-                | pulldown_cmark::Options::ENABLE_TASKLISTS
-                | pulldown_cmark::Options::ENABLE_TABLES
-                | pulldown_cmark::Options::ENABLE_FOOTNOTES
-                | pulldown_cmark::Options::ENABLE_HEADING_ATTRIBUTES;
-            let parser = pulldown_cmark::Parser::new_ext(&self.content, options).into_offset_iter();
-            for (event, range) in parser {
-                let text = match event {
-                    pulldown_cmark::Event::Text(text) | pulldown_cmark::Event::Code(text) => text,
-                    _ => continue,
-                };
-                let haystack = text.to_lowercase();
-                let mut start = 0;
-                while let Some(pos) = haystack[start..].find(&query) {
-                    let match_start = range.start + start + pos;
-                    let match_end = match_start + query.len();
-                    self.search_matches.push(match_start..match_end);
-                    start += pos + query.len();
-                }
-            }
-        }
-        self.cache.set_search_ranges(self.search_matches.clone());
-
-        if self.search_matches.is_empty() {
-            self.active_match = None;
-            self.sync_active_match();
-            return;
-        }
-
-        let nearest = self
-            .search_matches
-            .iter()
-            .position(|r| r.start >= anchor)
-            .unwrap_or(0);
-        self.active_match = Some(nearest);
-        self.sync_active_match();
-        self.cache.scroll_to_active_search_match();
-        // Suppress viewport-sync for ~30 frames so the animation toward the
-        // new match is not immediately overridden by the centering drift
-        // (viewport start lands before the active match when centred on screen).
-        self.search_scroll_protection = 30;
-    }
-
-    fn sync_active_match(&mut self) {
-        self.cache.set_active_search_range(
-            self.active_match
-                .and_then(|i| self.search_matches.get(i))
-                .cloned(),
-        );
-    }
-
-    fn go_to_match(&mut self, delta: isize) {
-        if self.search_matches.is_empty() {
-            return;
-        }
-        let len = self.search_matches.len() as isize;
-        let next = match self.active_match {
-            Some(i) => (i as isize + delta).rem_euclid(len),
-            // First navigation after a fresh search: start at the first
-            // match for Next, the last one for Previous.
-            None if delta >= 0 => 0,
-            None => len - 1,
-        };
-        self.active_match = Some(next as usize);
-        self.sync_active_match();
-        self.cache.scroll_to_active_search_match();
-        self.search_scroll_protection = 30;
-    }
-}
+impl App {}
 
 impl eframe::App for App {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
@@ -145,9 +28,11 @@ impl eframe::App for App {
         egui::Panel::top("search_bar").show(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.label("Search:");
-                let response = ui.text_edit_singleline(&mut self.search_query);
+                let response = ui.text_edit_singleline(&mut self.cache.search_query);
                 if response.changed() {
-                    self.update_search_matches();
+                    self.cache
+                        .update_search_matches(EGUI_SOURCE_ID, &self.content);
+                    // self.update_search_matches();
                 }
                 // Checked unconditionally (not gated on the text edit still
                 // having focus): a single-line TextEdit surrenders focus the
@@ -160,8 +45,8 @@ impl eframe::App for App {
                     response.request_focus();
                 }
 
-                let match_count = self.search_matches.len();
-                ui.label(match self.active_match {
+                let match_count = self.cache.search_ranges().len();
+                ui.label(match self.cache.active_match() {
                     Some(i) if match_count > 0 => format!("{}/{match_count}", i + 1),
                     _ => format!("0/{match_count}"),
                 });
@@ -169,12 +54,12 @@ impl eframe::App for App {
                 if ui.button("Previous").clicked()
                     || (enter_pressed && ui.input(|i| i.modifiers.shift))
                 {
-                    self.go_to_match(-1);
+                    self.cache.go_to_match(-1);
                 }
                 if ui.button("Next").clicked()
                     || (enter_pressed && !ui.input(|i| i.modifiers.shift))
                 {
-                    self.go_to_match(1);
+                    self.cache.go_to_match(1);
                 }
             });
         });
@@ -182,7 +67,7 @@ impl eframe::App for App {
         egui::CentralPanel::default().show(ui, |ui| {
             ui.style_mut().spacing.scroll = egui::style::ScrollStyle::thin();
 
-            let _user_scrolled = self.cache.handle_keyboard_scrolling(ui);
+            let user_scrolled = self.cache.handle_keyboard_scrolling(ui);
 
             CommonMarkViewer::new()
                 .max_image_width(Some(512))
@@ -190,42 +75,11 @@ impl eframe::App for App {
                 .viewport_cache(self.viewport_cache)
                 .show_scrollable(EGUI_SOURCE_ID, ui, &mut self.cache, &self.content);
 
-            // After show_scrollable the viewer has applied any pending scroll
-            // delta and updated the byte-offset tracker.  Sync active_match
-            // whenever the viewport byte offset actually changed AND no search
-            // scroll is still animating.  This fires on every animation frame
-            // (not just the key-press frame), so even large PageDown jumps
-            // settle to the correct match once the animation completes.
-            let current_offset = self
-                .cache
-                .viewport_start_byte_offset(EGUI_SOURCE_ID)
-                .unwrap_or(0);
-
-            if !self.search_matches.is_empty()
-                && self.search_scroll_protection == 0
-                && current_offset != self.last_viewport_offset
-            {
-                let len = self.search_matches.len();
-                let idx = self
-                    .search_matches
-                    .partition_point(|r| r.start < current_offset);
-                let nearest = if idx > 0 {
-                    idx - 1
-                } else {
-                    len.saturating_sub(1)
-                };
-                if self.active_match != Some(nearest) {
-                    self.active_match = Some(nearest);
-                    self.sync_active_match();
-                    // Do NOT call scroll_to_active_search_match here: the
-                    // viewport is already where the user put it.
-                }
-            }
-
-            self.last_viewport_offset = current_offset;
-            if self.search_scroll_protection > 0 {
-                self.search_scroll_protection -= 1;
-            }
+            self.cache.sync_scrollable_active_match(
+                EGUI_SOURCE_ID,
+                self.viewport_cache,
+                user_scrolled,
+            );
         });
     }
 }
@@ -256,11 +110,6 @@ fn main() -> eframe::Result {
                 cache: CommonMarkCache::default(),
                 content,
                 viewport_cache,
-                search_query: String::new(),
-                search_matches: Vec::new(),
-                active_match: None,
-                search_scroll_protection: 0,
-                last_viewport_offset: 0,
             }))
         }),
     )

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -29,10 +29,14 @@ impl App {
     /// `[Section 500](#section-500)`: once in the visible text, once in the
     /// URL).
     ///
-    /// Does not move the active match or scroll anywhere: navigation only
-    /// happens once the user explicitly commits via Next/Previous/Enter
-    /// (see `go_to_match`), so that live highlights appear as you type
-    /// without the view jumping around underneath you.
+    /// Recomputes `search_matches` on every keystroke and immediately
+    /// advances to the nearest match at or after wherever the user is
+    /// currently scrolled to (wrapping to the first match if there is none
+    /// after that point), mirroring how a normal "find in page" behaves.
+    /// Recomputation and the resulting scroll are both cheap (see
+    /// `CommonMarkCache::scroll_to_active_search_match`'s docs: this never
+    /// forces a full document re-render), so this stays responsive even for
+    /// this fairly large (~275 KB) document.
     fn update_search_matches(&mut self) {
         self.search_matches.clear();
         if !self.search_query.is_empty() {
@@ -62,11 +66,26 @@ impl App {
                 }
             }
         }
-        // Leave the active match unset; go_to_match() picks a starting point
-        // (first or last match) the first time the user navigates.
-        self.active_match = None;
         self.cache.set_search_ranges(self.search_matches.clone());
+
+        if self.search_matches.is_empty() {
+            self.active_match = None;
+            self.sync_active_match();
+            return;
+        }
+
+        let cursor = self
+            .cache
+            .viewport_start_byte_offset("scroll_example")
+            .unwrap_or(0);
+        let nearest = self
+            .search_matches
+            .iter()
+            .position(|r| r.start >= cursor)
+            .unwrap_or(0);
+        self.active_match = Some(nearest);
         self.sync_active_match();
+        self.cache.scroll_to_active_search_match();
     }
 
     fn sync_active_match(&mut self) {
@@ -106,8 +125,16 @@ impl eframe::App for App {
                 if response.changed() {
                     self.update_search_matches();
                 }
-                let enter_pressed =
-                    response.lost_focus() && ui.ctx().input(|i| i.key_pressed(egui::Key::Enter));
+                // Checked unconditionally (not gated on the text edit still
+                // having focus): a single-line TextEdit surrenders focus the
+                // moment Enter is pressed, so `response.has_focus()` would
+                // already be false here. We re-request focus below so that
+                // repeated Enter presses keep working without having to
+                // click back into the box each time.
+                let enter_pressed = ui.input(|i| i.key_pressed(egui::Key::Enter));
+                if enter_pressed {
+                    response.request_focus();
+                }
 
                 let match_count = self.search_matches.len();
                 ui.label(match self.active_match {

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -182,63 +182,7 @@ impl eframe::App for App {
         egui::CentralPanel::default().show(ui, |ui| {
             ui.style_mut().spacing.scroll = egui::style::ScrollStyle::thin();
 
-            let (
-                scroll_line_up,
-                scroll_line_down,
-                scroll_page_up,
-                scroll_page_down,
-                scroll_doc_top,
-                scroll_doc_bottom,
-            ) = ui.ctx().input(|i| {
-                use egui::Key;
-                (
-                    !i.modifiers.command && i.key_pressed(Key::ArrowUp),
-                    !i.modifiers.command && i.key_pressed(Key::ArrowDown),
-                    i.key_pressed(Key::PageUp),
-                    i.key_pressed(Key::PageDown),
-                    i.key_pressed(Key::Home)
-                        || (i.modifiers.command && i.key_pressed(Key::ArrowUp)),
-                    i.key_pressed(Key::End)
-                        || (i.modifiers.command && i.key_pressed(Key::ArrowDown)),
-                )
-            });
-
-            // Only act on scroll keys when no text field has focus.
-            if !ui.ctx().egui_wants_keyboard_input() {
-                let line_h = ui.text_style_height(&egui::TextStyle::Body);
-                let page_h = ui.available_height();
-                if scroll_line_up {
-                    self.cache.set_scroll_delta(egui::vec2(0.0, line_h));
-                } else if scroll_line_down {
-                    self.cache.set_scroll_delta(egui::vec2(0.0, -line_h));
-                } else if scroll_page_up {
-                    self.cache.set_scroll_delta(egui::vec2(0.0, page_h));
-                } else if scroll_page_down {
-                    self.cache.set_scroll_delta(egui::vec2(0.0, -page_h));
-                } else if scroll_doc_top {
-                    self.cache.set_scroll_delta(egui::vec2(0.0, f32::MAX / 2.0));
-                } else if scroll_doc_bottom {
-                    self.cache
-                        .set_scroll_delta(egui::vec2(0.0, -f32::MAX / 2.0));
-                }
-            }
-
-            // Any explicit user scroll input immediately cancels protection so
-            // the user's scroll position always wins over search animation.
-            let user_scroll_input = {
-                let has_mouse = ui.input(|i| i.is_scrolling());
-                let has_kb = !ui.ctx().egui_wants_keyboard_input()
-                    && (scroll_line_up
-                        || scroll_line_down
-                        || scroll_page_up
-                        || scroll_page_down
-                        || scroll_doc_top
-                        || scroll_doc_bottom);
-                has_mouse || has_kb
-            };
-            if user_scroll_input {
-                self.search_scroll_protection = 0;
-            }
+            let _user_scrolled = self.cache.handle_keyboard_scrolling(ui);
 
             CommonMarkViewer::new()
                 .max_image_width(Some(512))
@@ -262,15 +206,6 @@ impl eframe::App for App {
                 && current_offset != self.last_viewport_offset
             {
                 let len = self.search_matches.len();
-                // This works:
-                // let nearest = self
-                //     .search_matches
-                //     .iter()
-                //     .rposition(|r| r.start < current_offset)
-                //     // If the viewport is past the last match, show the last
-                //     // match rather than wrapping back to the first.
-                //     .unwrap_or(len - 1);
-                // Performance option:
                 let idx = self
                     .search_matches
                     .partition_point(|r| r.start < current_offset);

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -38,6 +38,19 @@ impl App {
     /// forces a full document re-render), so this stays responsive even for
     /// this fairly large (~275 KB) document.
     fn update_search_matches(&mut self) {
+        // Anchor to the byte position of the currently active match so that
+        // adding/removing characters from the query stays on the same spot.
+        // Fall back to the viewport position for a fresh (no active match)
+        // search.  Using viewport_start here on a query change would jump
+        // backwards whenever the viewport centre is a couple of sections
+        // before the active match (i.e. the match is centred on screen).
+        let anchor = self
+            .active_match
+            .and_then(|i| self.search_matches.get(i))
+            .map(|r| r.start)
+            .or_else(|| self.cache.viewport_start_byte_offset("scroll_example"))
+            .unwrap_or(0);
+
         self.search_matches.clear();
         if !self.search_query.is_empty() {
             let query = self.search_query.to_lowercase();
@@ -74,14 +87,10 @@ impl App {
             return;
         }
 
-        let cursor = self
-            .cache
-            .viewport_start_byte_offset("scroll_example")
-            .unwrap_or(0);
         let nearest = self
             .search_matches
             .iter()
-            .position(|r| r.start >= cursor)
+            .position(|r| r.start >= anchor)
             .unwrap_or(0);
         self.active_match = Some(nearest);
         self.sync_active_match();
@@ -199,11 +208,48 @@ impl eframe::App for App {
                 }
             }
 
+            // Detect genuine user-initiated scroll this frame (mouse wheel /
+            // trackpad OR keyboard scroll keys).  Programmatic search scrolls
+            // never produce these input events, so no suppress flag is needed.
+            let user_scrolled = !self.search_matches.is_empty() && {
+                let has_mouse_scroll = ui.input(|i| i.is_scrolling());
+                let has_kb_scroll = !ui.ctx().egui_wants_keyboard_input()
+                    && (scroll_line_up
+                        || scroll_line_down
+                        || scroll_page_up
+                        || scroll_page_down
+                        || scroll_doc_top
+                        || scroll_doc_bottom);
+                has_mouse_scroll || has_kb_scroll
+            };
+
             CommonMarkViewer::new()
                 .max_image_width(Some(512))
                 .enable_scroll_to_heading(true)
                 .viewport_cache(self.viewport_cache)
                 .show_scrollable("scroll_example", ui, &mut self.cache, &self.content);
+
+            // After the frame has rendered (scroll deltas applied), sync
+            // active_match to the nearest match at the new viewport position.
+            // Only do this for user-driven scrolls — search-initiated scrolls
+            // must not reset the match we just navigated to.
+            if user_scrolled {
+                let cursor = self
+                    .cache
+                    .viewport_start_byte_offset("scroll_example")
+                    .unwrap_or(0);
+                let nearest = self
+                    .search_matches
+                    .iter()
+                    .position(|r| r.start >= cursor)
+                    .unwrap_or(0);
+                if self.active_match != Some(nearest) {
+                    self.active_match = Some(nearest);
+                    self.sync_active_match();
+                    // Do NOT call scroll_to_active_search_match here: the
+                    // viewport is already where the user put it.
+                }
+            }
         });
     }
 }

--- a/egui_commonmark/examples/scroll.rs
+++ b/egui_commonmark/examples/scroll.rs
@@ -61,7 +61,7 @@ impl eframe::App for App {
         egui::CentralPanel::default().show(ui, |ui| {
             ui.style_mut().spacing.scroll = egui::style::ScrollStyle::thin();
 
-            // Handle any keyboard scrolling requests
+            // Handle any keyboard scrolling requests.
             let user_scrolled = self.cache.handle_keyboard_scrolling(ui);
 
             // `show_scrollable` will automatically scroll by any accumulated scroll amount
@@ -72,10 +72,11 @@ impl eframe::App for App {
                 .viewport_cache(self.viewport_cache)
                 .show_scrollable(&self.egui_source_id, ui, &mut self.cache, &self.content);
 
-            // Use the scrollable sync method to sync any search to the current viewport so
-            // that Next/Previous will continue from here instead of from its previous location.
-            // Unlike the regular `sync_active_match` method, this also supports new searches
-            // because it is confined to a range of known split points from the last full render.
+            // Optionally anchor any current search to the current viewport so that Next/Previous will
+            // continue from there instead of from its previous location.
+            // This call does not affect new searches. In `show-scrollable` mode these will always be
+            // anchored to the current viewport because the `egui_source_id` is passed in, whether or not
+            // the relevant sync active match method is called or `viewport_cache` is enabled.
             self.cache.sync_scrollable_active_match(
                 &self.egui_source_id,
                 self.viewport_cache,

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -157,6 +157,7 @@ impl eframe::App for App {
             ui.separator();
 
             egui::ScrollArea::vertical().show(ui, |ui| {
+                self.cache.apply_pending_scroll_delta(ui);
                 CommonMarkViewer::new().show(ui, &mut self.cache, MARKDOWN);
             });
         });

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -113,7 +113,6 @@ impl App {
                     self.search_matches.push(match_start..match_end);
                     start += pos + query.len();
                 }
-                // dbg!(&self.search_matches);
             }
         }
         self.cache.set_search_ranges(self.search_matches.clone());
@@ -128,13 +127,11 @@ impl App {
             .cache
             .viewport_start_byte_offset("search_example")
             .unwrap_or(0);
-        dbg!(&cursor);
         let nearest = self
             .search_matches
             .iter()
             .position(|r| r.start >= cursor)
             .unwrap_or(0);
-        dbg!(&nearest);
         self.active_match = Some(nearest);
         self.sync_active_match();
         self.cache.scroll_to_active_search_match();

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -131,16 +131,13 @@ impl eframe::App for App {
                     // Optionally override default search match colors
                     .search_active_match_color(active_bg)
                     .search_match_color(match_bg)
-                    .show(ui, &mut self.cache, MARKDOWN);
+                    .show_with_id("search_example", ui, &mut self.cache, MARKDOWN);
             });
 
-            // Use the regular sync method to sync any active search to the current viewport so
-            // that Next/Previous will continue from here instead of from its previous location.
-            // With `CommonMarkViewer::show`, this only syncs an existing search. To sync a new
-            // search would require a full render to extract virtual-y positions for all the
-            // matches, so instead we start a new search from the top of the document.
-            // See the `scroll` example for a `show_scrollable` example that (in viewport
-            // caching mode) does not have this restriction.
+            // Sync the active match to the current viewport so that Next/Previous advance
+            // from the current scroll position. Because show_with_id builds split points on
+            // every layout-width change, update_search_matches can also anchor fresh searches
+            // to the viewport — not just continue an existing one.
             self.cache.sync_active_match(user_scrolled);
         });
     }

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -113,61 +113,7 @@ impl eframe::App for App {
         egui::CentralPanel::default().show(ui, |ui| {
             ui.style_mut().spacing.scroll = egui::style::ScrollStyle::thin();
 
-            let (
-                scroll_line_up,
-                scroll_line_down,
-                scroll_page_up,
-                scroll_page_down,
-                scroll_doc_top,
-                scroll_doc_bottom,
-            ) = ui.ctx().input(|i| {
-                use egui::Key;
-                (
-                    !i.modifiers.command && i.key_pressed(Key::ArrowUp),
-                    !i.modifiers.command && i.key_pressed(Key::ArrowDown),
-                    i.key_pressed(Key::PageUp),
-                    i.key_pressed(Key::PageDown),
-                    i.key_pressed(Key::Home)
-                        || (i.modifiers.command && i.key_pressed(Key::ArrowUp)),
-                    i.key_pressed(Key::End)
-                        || (i.modifiers.command && i.key_pressed(Key::ArrowDown)),
-                )
-            });
-
-            // Only act on scroll keys when no text field has focus.
-            let no_text_focus = !ui.ctx().egui_wants_keyboard_input();
-            if no_text_focus {
-                let line_h = ui.text_style_height(&egui::TextStyle::Body);
-                let page_h = ui.available_height();
-                if scroll_line_up {
-                    self.cache.set_scroll_delta(egui::vec2(0.0, line_h));
-                } else if scroll_line_down {
-                    self.cache.set_scroll_delta(egui::vec2(0.0, -line_h));
-                } else if scroll_page_up {
-                    self.cache.set_scroll_delta(egui::vec2(0.0, page_h));
-                } else if scroll_page_down {
-                    self.cache.set_scroll_delta(egui::vec2(0.0, -page_h));
-                } else if scroll_doc_top {
-                    self.cache.set_scroll_delta(egui::vec2(0.0, f32::MAX / 2.0));
-                } else if scroll_doc_bottom {
-                    self.cache
-                        .set_scroll_delta(egui::vec2(0.0, -f32::MAX / 2.0));
-                }
-            }
-
-            // Detect any explicit user scroll input this frame: mouse wheel or
-            // keyboard arrows/pages (when a text field does not have focus).
-            // Passed to sync_active_match_to_viewport so that user scrolling
-            // immediately cancels post-search scroll protection and re-anchors
-            // the active match to the new viewport position.
-            let user_scrolled = ui.input(|i| i.is_scrolling())
-                || (no_text_focus
-                    && (scroll_line_up
-                        || scroll_line_down
-                        || scroll_page_up
-                        || scroll_page_down
-                        || scroll_doc_top
-                        || scroll_doc_bottom));
+            let user_scrolled = self.cache.handle_keyboard_scrolling(ui);
 
             ui.separator();
 

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -65,6 +65,7 @@ at your option.
 
 struct App {
     cache: CommonMarkCache,
+    egui_source_id: String,
 }
 
 impl App {}
@@ -78,7 +79,8 @@ impl eframe::App for App {
                 ui.label("Search:");
                 let response = ui.text_edit_singleline(&mut self.cache.search_query);
                 if response.changed() {
-                    self.cache.update_search_matches("search_example", MARKDOWN);
+                    self.cache
+                        .update_search_matches(&self.egui_source_id, MARKDOWN);
                 }
                 // Checked unconditionally (not gated on the text edit still
                 // having focus): a single-line TextEdit surrenders focus the
@@ -131,7 +133,7 @@ impl eframe::App for App {
                     // Optionally override default search match colors
                     .search_active_match_color(active_bg)
                     .search_match_color(match_bg)
-                    .show_with_id("search_example", ui, &mut self.cache, MARKDOWN);
+                    .show_with_id(&self.egui_source_id, ui, &mut self.cache, MARKDOWN);
             });
 
             // Sync the active match to the current viewport so that Next/Previous advance
@@ -160,6 +162,7 @@ fn main() -> eframe::Result {
             }
             Ok(Box::new(App {
                 cache: CommonMarkCache::default(),
+                egui_source_id: String::from("search_example"),
             }))
         }),
     )

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -135,7 +135,8 @@ impl eframe::App for App {
             });
 
             // Only act on scroll keys when no text field has focus.
-            if !ui.ctx().egui_wants_keyboard_input() {
+            let no_text_focus = !ui.ctx().egui_wants_keyboard_input();
+            if no_text_focus {
                 let line_h = ui.text_style_height(&egui::TextStyle::Body);
                 let page_h = ui.available_height();
                 if scroll_line_up {
@@ -154,12 +155,31 @@ impl eframe::App for App {
                 }
             }
 
+            // Detect any explicit user scroll input this frame: mouse wheel or
+            // keyboard arrows/pages (when a text field does not have focus).
+            // Passed to sync_active_match_to_viewport so that user scrolling
+            // immediately cancels post-search scroll protection and re-anchors
+            // the active match to the new viewport position.
+            let user_scrolled = ui.input(|i| i.is_scrolling())
+                || (no_text_focus
+                    && (scroll_line_up
+                        || scroll_line_down
+                        || scroll_page_up
+                        || scroll_page_down
+                        || scroll_doc_top
+                        || scroll_doc_bottom));
+
             ui.separator();
 
             egui::ScrollArea::vertical().show(ui, |ui| {
                 self.cache.apply_pending_scroll_delta(ui);
                 CommonMarkViewer::new().show(ui, &mut self.cache, MARKDOWN);
             });
+
+            // After show() the cache holds fresh per-match virtual-y positions
+            // and the current viewport top. Sync the active match so that
+            // Next/Previous advance from wherever the user has scrolled to.
+            self.cache.sync_active_match_to_viewport(user_scrolled);
         });
     }
 }

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -113,19 +113,35 @@ impl eframe::App for App {
         egui::CentralPanel::default().show(ui, |ui| {
             ui.style_mut().spacing.scroll = egui::style::ScrollStyle::thin();
 
+            // Handle any keyboard scrolling requests
             let user_scrolled = self.cache.handle_keyboard_scrolling(ui);
 
             ui.separator();
 
+            // Optional custom search match highlight colors.
+            // Using `egui` themed colors saves us interrogating `ui.visuals()` to see
+            // if we're in light or dark mode and choosing suitable colors accordingly.
+            let active_bg = ui.visuals().selection.bg_fill;
+            let match_bg = active_bg.gamma_multiply(0.6);
+
             egui::ScrollArea::vertical().show(ui, |ui| {
+                // Scroll by accumulated scroll amount before rendering
                 self.cache.apply_pending_scroll_delta(ui);
-                CommonMarkViewer::new().show(ui, &mut self.cache, MARKDOWN);
+                CommonMarkViewer::new()
+                    // Optionally override default search match colors
+                    .search_active_match_color(active_bg)
+                    .search_match_color(match_bg)
+                    .show(ui, &mut self.cache, MARKDOWN);
             });
 
-            // After show() the cache holds fresh per-match virtual-y positions
-            // and the current viewport top. Sync the active match so that
-            // Next/Previous advance from wherever the user has scrolled to.
-            self.cache.sync_active_match_to_viewport(user_scrolled);
+            // Use the regular sync method to sync any active search to the current viewport so
+            // that Next/Previous will continue from here instead of from its previous location.
+            // With `CommonMarkViewer::show`, this only syncs an existing search. To sync a new
+            // search would require a full render to extract virtual-y positions for all the
+            // matches, so instead we start a new search from the top of the document.
+            // See the `scroll` example for a `show_scrollable` example that (in viewport
+            // caching mode) does not have this restriction.
+            self.cache.sync_active_match(user_scrolled);
         });
     }
 }

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -88,6 +88,7 @@ impl eframe::App for App {
                     response.clone().on_hover_text(error);
                 }
 
+                // Lay out and test search options
                 let search_options_changed = self.search_options_changed(ui);
 
                 if search_options_changed || response.changed() {
@@ -139,6 +140,8 @@ impl eframe::App for App {
             let active_bg = ui.visuals().selection.bg_fill;
             let match_bg = active_bg.gamma_multiply(0.6);
 
+            // To anchor searches to the scroll position, optionally replace `show` by `show_with_id`
+            // and then call `self.cache.sync_active_match`.
             egui::ScrollArea::vertical().show(ui, |ui| {
                 // Scroll by accumulated scroll amount before rendering
                 self.cache.apply_pending_scroll_delta(ui);
@@ -149,16 +152,19 @@ impl eframe::App for App {
                     .show_with_id(&self.egui_source_id, ui, &mut self.cache, MARKDOWN);
             });
 
-            // Sync the active match to the current viewport so that Next/Previous advance
-            // from the current scroll position. Because show_with_id builds split points on
-            // every layout-width change, update_search_matches can also anchor fresh searches
-            // to the viewport — not just continue an existing one.
+            // Optionally anchor any current or new search to the current viewport so that
+            // Next/Previous will continue from there instead of from its previous location.
+            // New searches are affected only when using regular `CommonMarkViewer::show`:
+            // without this call they will start from the top of the document.
+            // When using `CommonMarkViewer::show_with_id`, new searches will always be
+            // anchored to the current viewport anyway, thanks to the `egui_source_id` argument.
             self.cache.sync_active_match(user_scrolled);
         });
     }
 }
 
 impl App {
+    // Lays out the search option buttons and checks if they've changed from frame to frame.
     fn search_options_changed(&mut self, ui: &mut egui::Ui) -> bool {
         let mut search_options_changed = false;
 

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -1,0 +1,289 @@
+//! Demonstrates search-match highlighting with default colors.
+//!
+//! Typing in the search bar highlights every match. Prev/Next step through
+//! matches and scroll the document to centre each one in the viewport.
+//!
+//! Run with:
+//! `cargo r --example search [light|dark]`
+
+use eframe::egui;
+use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
+
+const MARKDOWN: &str = r#"# Search Highlighting
+
+Type text in the search bar above to highlight every occurrence in this document.
+Use **Prev** and **Next** to step through matches.
+
+Suggestion: try searching for "MIT" to see scrolling to a match near the bottom.
+
+---
+
+# A commonmark viewer for [egui](https://github.com/emilk/egui)
+
+While this crate's main focus is commonmark, it also supports a subset of
+Github's markdown syntax: tables, strikethrough, tasklists and footnotes.
+
+## Features
+
+* `macros`: macros for compile time parsing of markdown
+* `better_syntax_highlighting`: Syntax highlighting inside code blocks with
+  [`syntect`](https://crates.io/crates/syntect)
+* `svg`: Support for viewing svg images
+* `fetch`: Images with urls will be downloaded and displayed
+* `embedded_image`: Load base64 image data urls from within markdown files
+
+
+## Examples
+
+For an easy intro check out the `hello_world` example. To see all the different
+features egui_commonmark has to offer check out the `book` example.
+
+## FAQ
+
+### URL is not displayed when hovering over a link
+
+By default egui does not show urls when you hover hyperlinks. To enable it,
+you can do the following before calling any ui related functions:
+
+```rust
+ui.style_mut().url_in_tooltip = true;
+```
+
+## MSRV Policy
+
+This crate uses the same MSRV as the latest released egui version.
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+"#;
+
+struct App {
+    cache: CommonMarkCache,
+    search_query: String,
+    search_matches: Vec<std::ops::Range<usize>>,
+    active_match: Option<usize>,
+}
+
+impl App {
+    /// Recomputes `search_matches` from the *rendered* text only (via
+    /// pulldown-cmark's `Text`/`Code` events), so link destinations,
+    /// heading `{#id}` attribute syntax, and other non-visible markdown
+    /// syntax are never matched (a naive substring search over the raw
+    /// source would, for example, double-count "500" in
+    /// `[Section 500](#section-500)`: once in the visible text, once in the
+    /// URL).
+    ///
+    /// Recomputes `search_matches` on every keystroke and immediately
+    /// advances to the nearest match at or after wherever the user is
+    /// currently scrolled to (wrapping to the first match if there is none
+    /// after that point), mirroring how a normal "find in page" behaves.
+    /// Recomputation and the resulting scroll are both cheap (see
+    /// `CommonMarkCache::scroll_to_active_search_match`'s docs: this never
+    /// forces a full document re-render), so this shoud stay responsive.
+    fn update_search_matches(&mut self) {
+        self.search_matches.clear();
+        if !self.search_query.is_empty() {
+            let query = self.search_query.to_lowercase();
+            // Mirror the options CommonMarkViewer itself parses with,
+            // including heading attributes since `enable_scroll_to_heading`
+            // is set below (otherwise `{#section-500}` would remain in the
+            // heading's Text event and get matched too).
+            let options = pulldown_cmark::Options::ENABLE_STRIKETHROUGH
+                | pulldown_cmark::Options::ENABLE_TASKLISTS
+                | pulldown_cmark::Options::ENABLE_TABLES
+                | pulldown_cmark::Options::ENABLE_FOOTNOTES
+                | pulldown_cmark::Options::ENABLE_HEADING_ATTRIBUTES;
+            let parser = pulldown_cmark::Parser::new_ext(MARKDOWN, options).into_offset_iter();
+            for (event, range) in parser {
+                let text = match event {
+                    pulldown_cmark::Event::Text(text) | pulldown_cmark::Event::Code(text) => text,
+                    _ => continue,
+                };
+                let haystack = text.to_lowercase();
+                let mut start = 0;
+                while let Some(pos) = haystack[start..].find(&query) {
+                    let match_start = range.start + start + pos;
+                    let match_end = match_start + query.len();
+                    self.search_matches.push(match_start..match_end);
+                    start += pos + query.len();
+                }
+                // dbg!(&self.search_matches);
+            }
+        }
+        self.cache.set_search_ranges(self.search_matches.clone());
+
+        if self.search_matches.is_empty() {
+            self.active_match = None;
+            self.sync_active_match();
+            return;
+        }
+
+        let cursor = self
+            .cache
+            .viewport_start_byte_offset("search_example")
+            .unwrap_or(0);
+        dbg!(&cursor);
+        let nearest = self
+            .search_matches
+            .iter()
+            .position(|r| r.start >= cursor)
+            .unwrap_or(0);
+        dbg!(&nearest);
+        self.active_match = Some(nearest);
+        self.sync_active_match();
+        self.cache.scroll_to_active_search_match();
+    }
+
+    fn sync_active_match(&mut self) {
+        self.cache.set_active_search_range(
+            self.active_match
+                .and_then(|i| {
+                    dbg!(i);
+                    self.search_matches.get(i)
+                })
+                .cloned(),
+        );
+    }
+
+    fn go_to_match(&mut self, delta: isize) {
+        if self.search_matches.is_empty() {
+            return;
+        }
+        let len = self.search_matches.len() as isize;
+        let next = match self.active_match {
+            Some(i) => (i as isize + delta).rem_euclid(len),
+            // First navigation after a fresh search: start at the first
+            // match for Next, the last one for Previous.
+            None if delta >= 0 => 0,
+            None => len - 1,
+        };
+        self.active_match = Some(next as usize);
+        self.sync_active_match();
+        self.cache.scroll_to_active_search_match();
+    }
+}
+
+impl eframe::App for App {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        ui.set_min_height(512.0);
+
+        egui::Panel::top("search_bar").show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Search:");
+                let response = ui.text_edit_singleline(&mut self.search_query);
+                if response.changed() {
+                    self.update_search_matches();
+                }
+                // Checked unconditionally (not gated on the text edit still
+                // having focus): a single-line TextEdit surrenders focus the
+                // moment Enter is pressed, so `response.has_focus()` would
+                // already be false here. We re-request focus below so that
+                // repeated Enter presses keep working without having to
+                // click back into the box each time.
+                let enter_pressed = ui.input(|i| i.key_pressed(egui::Key::Enter));
+                if enter_pressed {
+                    response.request_focus();
+                }
+
+                let match_count = self.search_matches.len();
+                ui.label(match self.active_match {
+                    Some(i) if match_count > 0 => format!("{}/{match_count}", i + 1),
+                    _ => format!("0/{match_count}"),
+                });
+
+                if ui.button("Previous").clicked()
+                    || (enter_pressed && ui.input(|i| i.modifiers.shift))
+                {
+                    self.go_to_match(-1);
+                }
+                if ui.button("Next").clicked()
+                    || (enter_pressed && !ui.input(|i| i.modifiers.shift))
+                {
+                    self.go_to_match(1);
+                }
+            });
+        });
+
+        egui::CentralPanel::default().show(ui, |ui| {
+            ui.style_mut().spacing.scroll = egui::style::ScrollStyle::thin();
+
+            let (
+                scroll_line_up,
+                scroll_line_down,
+                scroll_page_up,
+                scroll_page_down,
+                scroll_doc_top,
+                scroll_doc_bottom,
+            ) = ui.ctx().input(|i| {
+                use egui::Key;
+                (
+                    !i.modifiers.command && i.key_pressed(Key::ArrowUp),
+                    !i.modifiers.command && i.key_pressed(Key::ArrowDown),
+                    i.key_pressed(Key::PageUp),
+                    i.key_pressed(Key::PageDown),
+                    i.key_pressed(Key::Home)
+                        || (i.modifiers.command && i.key_pressed(Key::ArrowUp)),
+                    i.key_pressed(Key::End)
+                        || (i.modifiers.command && i.key_pressed(Key::ArrowDown)),
+                )
+            });
+
+            // Only act on scroll keys when no text field has focus.
+            if !ui.ctx().egui_wants_keyboard_input() {
+                let line_h = ui.text_style_height(&egui::TextStyle::Body);
+                let page_h = ui.available_height();
+                if scroll_line_up {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, line_h));
+                } else if scroll_line_down {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, -line_h));
+                } else if scroll_page_up {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, page_h));
+                } else if scroll_page_down {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, -page_h));
+                } else if scroll_doc_top {
+                    self.cache.set_scroll_delta(egui::vec2(0.0, f32::MAX / 2.0));
+                } else if scroll_doc_bottom {
+                    self.cache
+                        .set_scroll_delta(egui::vec2(0.0, -f32::MAX / 2.0));
+                }
+            }
+
+            ui.separator();
+
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                CommonMarkViewer::new().show(ui, &mut self.cache, MARKDOWN);
+            });
+        });
+    }
+}
+
+fn main() -> eframe::Result {
+    let mut args = std::env::args();
+    args.next();
+
+    eframe::run_native(
+        "Markdown search example",
+        eframe::NativeOptions::default(),
+        Box::new(move |cc| {
+            if let Some(theme) = args.next() {
+                if theme == "light" {
+                    cc.egui_ctx.set_theme(egui::Theme::Light);
+                } else if theme == "dark" {
+                    cc.egui_ctx.set_theme(egui::Theme::Dark);
+                }
+            }
+            Ok(Box::new(App {
+                cache: CommonMarkCache::default(),
+                search_query: String::new(),
+                search_matches: Vec::new(),
+                active_match: None,
+            }))
+        }),
+    )
+}

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -7,7 +7,7 @@
 //! `cargo r --example search [light|dark]`
 
 use eframe::egui;
-use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
+use egui_commonmark::{CommonMarkCache, CommonMarkViewer, SearchOptions};
 
 const MARKDOWN: &str = r#"# Search Highlighting
 
@@ -68,20 +68,33 @@ struct App {
     egui_source_id: String,
 }
 
-impl App {}
-
 impl eframe::App for App {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         ui.set_min_height(512.0);
 
         egui::Panel::top("search_bar").show(ui, |ui| {
             ui.horizontal(|ui| {
+                let text_color = if self.cache.search_regex_error.is_some() {
+                    ui.visuals().error_fg_color
+                } else {
+                    ui.visuals().text_color()
+                };
+
                 ui.label("Search:");
-                let response = ui.text_edit_singleline(&mut self.cache.search_query);
-                if response.changed() {
+                let response = ui.add(
+                    egui::TextEdit::singleline(&mut self.cache.search_query).text_color(text_color),
+                );
+                if let Some(error) = &self.cache.search_regex_error {
+                    response.clone().on_hover_text(error);
+                }
+
+                let search_options_changed = self.search_options_changed(ui);
+
+                if search_options_changed || response.changed() {
                     self.cache
                         .update_search_matches(&self.egui_source_id, MARKDOWN);
                 }
+
                 // Checked unconditionally (not gated on the text edit still
                 // having focus): a single-line TextEdit surrenders focus the
                 // moment Enter is pressed, so `response.has_focus()` would
@@ -142,6 +155,48 @@ impl eframe::App for App {
             // to the viewport — not just continue an existing one.
             self.cache.sync_active_match(user_scrolled);
         });
+    }
+}
+
+impl App {
+    fn search_options_changed(&mut self, ui: &mut egui::Ui) -> bool {
+        let mut search_options_changed = false;
+
+        let mut search_toggle =
+            |ui: &mut egui::Ui, flag: SearchOptions, label: egui::WidgetText, tooltip: String| {
+                let selected = self.cache.search_options.contains(flag);
+
+                if ui
+                    .selectable_label(selected, label)
+                    .on_hover_text(tooltip)
+                    .clicked()
+                {
+                    self.cache.search_options.toggle(flag);
+                    search_options_changed = true;
+                }
+            };
+
+        search_toggle(
+            ui,
+            SearchOptions::CASE_SENSITIVE,
+            "Aa".into(),
+            "Case sensitive search".to_string(),
+        );
+
+        search_toggle(
+            ui,
+            SearchOptions::WHOLE_WORD,
+            egui::RichText::new("wd").underline().into(),
+            "Whole word search".to_string(),
+        );
+
+        search_toggle(
+            ui,
+            SearchOptions::REGEX,
+            ".*".into(),
+            "Regex search".to_string(),
+        );
+        search_options_changed
     }
 }
 

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -65,103 +65,9 @@ at your option.
 
 struct App {
     cache: CommonMarkCache,
-    search_query: String,
-    search_matches: Vec<std::ops::Range<usize>>,
-    active_match: Option<usize>,
 }
 
-impl App {
-    /// Recomputes `search_matches` from the *rendered* text only (via
-    /// pulldown-cmark's `Text`/`Code` events), so link destinations,
-    /// heading `{#id}` attribute syntax, and other non-visible markdown
-    /// syntax are never matched (a naive substring search over the raw
-    /// source would, for example, double-count "500" in
-    /// `[Section 500](#section-500)`: once in the visible text, once in the
-    /// URL).
-    ///
-    /// Recomputes `search_matches` on every keystroke and immediately
-    /// advances to the nearest match at or after wherever the user is
-    /// currently scrolled to (wrapping to the first match if there is none
-    /// after that point), mirroring how a normal "find in page" behaves.
-    /// Recomputation and the resulting scroll are both cheap (see
-    /// `CommonMarkCache::scroll_to_active_search_match`'s docs: this never
-    /// forces a full document re-render), so this shoud stay responsive.
-    fn update_search_matches(&mut self) {
-        self.search_matches.clear();
-        if !self.search_query.is_empty() {
-            let query = self.search_query.to_lowercase();
-            // Mirror the options CommonMarkViewer itself parses with,
-            // including heading attributes since `enable_scroll_to_heading`
-            // is set below (otherwise `{#section-500}` would remain in the
-            // heading's Text event and get matched too).
-            let options = pulldown_cmark::Options::ENABLE_STRIKETHROUGH
-                | pulldown_cmark::Options::ENABLE_TASKLISTS
-                | pulldown_cmark::Options::ENABLE_TABLES
-                | pulldown_cmark::Options::ENABLE_FOOTNOTES
-                | pulldown_cmark::Options::ENABLE_HEADING_ATTRIBUTES;
-            let parser = pulldown_cmark::Parser::new_ext(MARKDOWN, options).into_offset_iter();
-            for (event, range) in parser {
-                let text = match event {
-                    pulldown_cmark::Event::Text(text) | pulldown_cmark::Event::Code(text) => text,
-                    _ => continue,
-                };
-                let haystack = text.to_lowercase();
-                let mut start = 0;
-                while let Some(pos) = haystack[start..].find(&query) {
-                    let match_start = range.start + start + pos;
-                    let match_end = match_start + query.len();
-                    self.search_matches.push(match_start..match_end);
-                    start += pos + query.len();
-                }
-            }
-        }
-        self.cache.set_search_ranges(self.search_matches.clone());
-
-        if self.search_matches.is_empty() {
-            self.active_match = None;
-            self.sync_active_match();
-            return;
-        }
-
-        let cursor = self
-            .cache
-            .viewport_start_byte_offset("search_example")
-            .unwrap_or(0);
-        let nearest = self
-            .search_matches
-            .iter()
-            .position(|r| r.start >= cursor)
-            .unwrap_or(0);
-        self.active_match = Some(nearest);
-        self.sync_active_match();
-        self.cache.scroll_to_active_search_match();
-    }
-
-    fn sync_active_match(&mut self) {
-        self.cache.set_active_search_range(
-            self.active_match
-                .and_then(|i| self.search_matches.get(i))
-                .cloned(),
-        );
-    }
-
-    fn go_to_match(&mut self, delta: isize) {
-        if self.search_matches.is_empty() {
-            return;
-        }
-        let len = self.search_matches.len() as isize;
-        let next = match self.active_match {
-            Some(i) => (i as isize + delta).rem_euclid(len),
-            // First navigation after a fresh search: start at the first
-            // match for Next, the last one for Previous.
-            None if delta >= 0 => 0,
-            None => len - 1,
-        };
-        self.active_match = Some(next as usize);
-        self.sync_active_match();
-        self.cache.scroll_to_active_search_match();
-    }
-}
+impl App {}
 
 impl eframe::App for App {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
@@ -170,9 +76,9 @@ impl eframe::App for App {
         egui::Panel::top("search_bar").show(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.label("Search:");
-                let response = ui.text_edit_singleline(&mut self.search_query);
+                let response = ui.text_edit_singleline(&mut self.cache.search_query);
                 if response.changed() {
-                    self.update_search_matches();
+                    self.cache.update_search_matches("search_example", MARKDOWN);
                 }
                 // Checked unconditionally (not gated on the text edit still
                 // having focus): a single-line TextEdit surrenders focus the
@@ -185,8 +91,8 @@ impl eframe::App for App {
                     response.request_focus();
                 }
 
-                let match_count = self.search_matches.len();
-                ui.label(match self.active_match {
+                let match_count = self.cache.search_ranges().len();
+                ui.label(match self.cache.active_match() {
                     Some(i) if match_count > 0 => format!("{}/{match_count}", i + 1),
                     _ => format!("0/{match_count}"),
                 });
@@ -194,12 +100,12 @@ impl eframe::App for App {
                 if ui.button("Previous").clicked()
                     || (enter_pressed && ui.input(|i| i.modifiers.shift))
                 {
-                    self.go_to_match(-1);
+                    self.cache.go_to_match(-1);
                 }
                 if ui.button("Next").clicked()
                     || (enter_pressed && !ui.input(|i| i.modifiers.shift))
                 {
-                    self.go_to_match(1);
+                    self.cache.go_to_match(1);
                 }
             });
         });
@@ -274,9 +180,6 @@ fn main() -> eframe::Result {
             }
             Ok(Box::new(App {
                 cache: CommonMarkCache::default(),
-                search_query: String::new(),
-                search_matches: Vec::new(),
-                active_match: None,
             }))
         }),
     )

--- a/egui_commonmark/examples/search.rs
+++ b/egui_commonmark/examples/search.rs
@@ -143,10 +143,7 @@ impl App {
     fn sync_active_match(&mut self) {
         self.cache.set_active_search_range(
             self.active_match
-                .and_then(|i| {
-                    dbg!(i);
-                    self.search_matches.get(i)
-                })
+                .and_then(|i| self.search_matches.get(i))
                 .cloned(),
         );
     }

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -79,7 +79,7 @@ mod parsers;
 pub use egui_commonmark_backend::RenderHtmlFn;
 pub use egui_commonmark_backend::RenderMathFn;
 pub use egui_commonmark_backend::alerts::{Alert, AlertBundle};
-pub use egui_commonmark_backend::misc::CommonMarkCache;
+pub use egui_commonmark_backend::misc::{CommonMarkCache, SearchOptions};
 
 #[cfg(feature = "better_syntax_highlighting")]
 pub use egui_commonmark_backend::syntect;

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -261,7 +261,11 @@ impl<'f> CommonMarkViewer<'f> {
         self
     }
 
-    /// Shows rendered markdown
+    /// Shows rendered markdown.
+    ///
+    /// For viewport-aware search (anchoring new searches to the current scroll
+    /// position rather than the document top), use
+    /// [`show_with_id`](Self::show_with_id) instead.
     pub fn show(
         self,
         ui: &mut egui::Ui,
@@ -279,6 +283,34 @@ impl<'f> CommonMarkViewer<'f> {
         );
 
         response
+    }
+
+    /// Like [`show`](Self::show), but tracks the viewport position so that
+    /// [`update_search_matches`](CommonMarkCache::update_search_matches) anchors
+    /// new searches to the current scroll location instead of always starting
+    /// from the document top.
+    ///
+    /// `source_id` must be stable across frames and unique to this viewer
+    /// instance. Pass the same string to `update_search_matches` and
+    /// [`sync_active_match`](CommonMarkCache::sync_active_match).
+    ///
+    /// Split-point positions are rebuilt when the available width changes and
+    /// cached otherwise, so the overhead is paid only on the first frame and
+    /// after window resizes.
+    ///
+    /// For large documents where rendering the full content every frame is too
+    /// slow, prefer [`show_scrollable`](Self::show_scrollable), which shares
+    /// the same viewport-tracking capability but additionally renders only the
+    /// visible slice each frame.
+    pub fn show_with_id(
+        mut self,
+        source_id: impl egui::AsId,
+        ui: &mut egui::Ui,
+        cache: &mut CommonMarkCache,
+        text: &str,
+    ) -> egui::InnerResponse<()> {
+        self.options.source_id = Some(egui::Id::new(source_id));
+        self.show(ui, cache, text)
     }
 
     /// Shows rendered markdown, and allows the rendered ui to mutate the source text.

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -232,6 +232,17 @@ impl<'f> CommonMarkViewer<'f> {
         self
     }
 
+    /// When `true`, [`show_scrollable`] only renders the visible slice of the
+    /// document each frame, keeping large documents fast. When `false` (the
+    /// default) the full document is rendered every frame and egui clips what
+    /// is off-screen, which is simpler and sufficient for most documents.
+    ///
+    /// [`show_scrollable`]: Self::show_scrollable
+    pub fn viewport_cache(mut self, enable: bool) -> Self {
+        self.options.use_viewport_cache = enable;
+        self
+    }
+
     /// Shows rendered markdown
     pub fn show(
         self,

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -243,6 +243,24 @@ impl<'f> CommonMarkViewer<'f> {
         self
     }
 
+    /// Override the background colour used to highlight passive (non-active)
+    /// search matches (see [`CommonMarkCache::set_search_ranges`]). By
+    /// default a theme-derived colour is used, so this is only needed if you
+    /// want something else.
+    pub fn search_match_color(mut self, color: egui::Color32) -> Self {
+        self.options.search_match_bg = Some(color);
+        self
+    }
+
+    /// Override the background colour used to highlight the active (focused)
+    /// search match (see [`CommonMarkCache::set_active_search_range`]). By
+    /// default a theme-derived colour is used, so this is only needed if you
+    /// want something else.
+    pub fn search_active_match_color(mut self, color: egui::Color32) -> Self {
+        self.options.search_active_match_bg = Some(color);
+        self
+    }
+
     /// Shows rendered markdown
     pub fn show(
         self,

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -371,7 +371,13 @@ impl List {
                 bullet_point(ui);
             }
         } else {
-            unreachable!();
+            // The list stack is empty.  This can happen in the viewport-cache
+            // path when the visible slice starts with a Start(Item) event whose
+            // enclosing Start(List) fell just outside the rendered window.
+            // Synthesise a top-level unordered list level so the item renders
+            // reasonably rather than panicking.
+            self.start_level_without_number();
+            bullet_point(ui);
         }
 
         ui.add_space(4.0);

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -352,13 +352,6 @@ impl<'f> CommonMarkViewer<'f> {
     /// This function is much more performant than just calling [`show`] inside a [`ScrollArea`],
     /// because it only renders elements that are visible.
     ///
-    /// # Caveat
-    ///
-    /// This assumes that the markdown is static. If it does change, you have to clear the cache
-    /// by using [`clear_scrollable_with_id`](CommonMarkCache::clear_scrollable_with_id) or
-    /// [`clear_scrollable`](CommonMarkCache::clear_scrollable). If the content changes every frame,
-    /// it's faster to call [`show`] directly.
-    ///
     /// [`ScrollArea`]: egui::ScrollArea
     /// [`show`]: crate::CommonMarkViewer::show
     #[cfg(feature = "pulldown_cmark")]

--- a/egui_commonmark/src/lib.rs
+++ b/egui_commonmark/src/lib.rs
@@ -300,7 +300,6 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// [`ScrollArea`]: egui::ScrollArea
     /// [`show`]: crate::CommonMarkViewer::show
-    #[doc(hidden)] // Buggy in scenarios more complex than the example application
     #[cfg(feature = "pulldown_cmark")]
     pub fn show_scrollable(
         self,

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -9,6 +9,9 @@ use crate::List;
 use egui_commonmark_backend::elements::*;
 use egui_commonmark_backend::misc::*;
 use egui_commonmark_backend::pulldown::*;
+use egui_commonmark_backend::search::{
+    default_active_match_bg, default_match_bg, search_intervals,
+};
 use pulldown_cmark::{CowStr, HeadingLevel};
 
 /// Newline logic is constructed by the following:
@@ -88,6 +91,11 @@ pub struct CommonMarkViewerInternal {
     /// still loading). When true, split points are discarded and the full render
     /// repeats next frame until all images have stable heights.
     any_image_loading: bool,
+    /// Taken from [`CommonMarkCache::take_pending_scroll_to_active_match`] at
+    /// the start of a render pass. When true, the renderer scrolls to (and
+    /// centers) the active search match the moment it is found, then clears
+    /// this flag so it only happens once per pass.
+    want_scroll_to_active_match: bool,
 }
 
 pub(crate) struct CheckboxClickEvent {
@@ -113,6 +121,7 @@ impl CommonMarkViewerInternal {
             checkbox_events: Vec::new(),
             deferred_scroll_to_heading: None,
             any_image_loading: false,
+            want_scroll_to_active_match: false,
         }
     }
 }
@@ -143,6 +152,7 @@ impl CommonMarkViewerInternal {
         split_points_id: Option<Id>,
     ) -> (egui::InnerResponse<()>, Vec<CheckboxClickEvent>) {
         self.any_image_loading = false;
+        self.want_scroll_to_active_match = cache.take_pending_scroll_to_active_match();
         let max_width = options.max_width(ui);
         let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
 
@@ -292,6 +302,20 @@ impl CommonMarkViewerInternal {
                     apply_pending_scroll_delta(cache, ui);
                 });
             return;
+        }
+
+        if cache.has_pending_scroll_to_active_match() {
+            // The active match's position isn't tracked incrementally (unlike
+            // heading anchors), because it can change every time the user
+            // steps to the next/previous result without the document or
+            // available width changing (which would otherwise invalidate
+            // this cache naturally). Force one full render so the match can
+            // be located and scrolled to; subsequent frames go back to the
+            // cheap viewport-only path once the scroll position has settled.
+            let sc = scroll_cache(cache, &source_id);
+            sc.page_size = None;
+            sc.split_points.clear();
+            sc.heading_y_positions.clear();
         }
 
         let Some(page_size) = scroll_cache(cache, &source_id).page_size else {
@@ -716,22 +740,22 @@ impl CommonMarkViewerInternal {
             pulldown_cmark::Event::Start(tag) => self.start_tag(ui, tag, cache, options),
             pulldown_cmark::Event::End(tag) => self.end_tag(ui, tag, cache, options, max_width),
             pulldown_cmark::Event::Text(text) => {
-                self.event_text(text, ui);
+                self.event_text(text, src_span, ui, cache);
             }
             pulldown_cmark::Event::Code(text) => {
                 self.text_style.code = true;
-                self.event_text(text, ui);
+                self.event_text(text, src_span, ui, cache);
                 self.text_style.code = false;
             }
             pulldown_cmark::Event::InlineHtml(text) => {
-                self.event_text(text, ui);
+                self.event_text(text, src_span, ui, cache);
             }
 
             pulldown_cmark::Event::Html(text) => {
                 if options.html_fn.is_some() {
                     self.html_block.push_str(&text);
                 } else {
-                    self.event_text(text, ui);
+                    self.event_text(text, src_span, ui, cache);
                 }
             }
             pulldown_cmark::Event::FootnoteReference(footnote) => {
@@ -773,16 +797,41 @@ impl CommonMarkViewerInternal {
         }
     }
 
-    fn event_text(&mut self, text: CowStr, ui: &mut Ui) {
-        let rich_text = self.text_style.to_richtext(ui, &text);
+    fn event_text(
+        &mut self,
+        text: CowStr,
+        src_span: Range<usize>,
+        ui: &mut Ui,
+        cache: &mut CommonMarkCache,
+    ) {
         if let Some(image) = &mut self.image {
-            image.alt_text.push(rich_text);
+            image.alt_text.push(self.text_style.to_richtext(ui, &text));
         } else if let Some(block) = &mut self.code_block {
-            block.content.push_str(&text);
+            block.push_text(&text, src_span);
         } else if let Some(link) = &mut self.link {
-            link.text.push(rich_text);
+            link.text.push(self.text_style.to_richtext(ui, &text));
         } else {
-            ui.label(rich_text);
+            let rich_text = self.text_style.to_richtext(ui, &text);
+            let intervals = search_intervals(
+                cache.search_ranges(),
+                cache.active_search_range(),
+                &src_span,
+                text.len(),
+            );
+            let (_, active_rect) = label_with_search_highlight(
+                ui,
+                rich_text,
+                &intervals,
+                default_match_bg(),
+                default_active_match_bg(),
+            );
+
+            if self.want_scroll_to_active_match
+                && let Some(rect) = active_rect
+            {
+                ui.scroll_to_rect(rect, Some(egui::Align::Center));
+                self.want_scroll_to_active_match = false;
+            }
         }
     }
 
@@ -830,12 +879,14 @@ impl CommonMarkViewerInternal {
                         self.code_block = Some(crate::CodeBlock {
                             lang: Some(lang.to_string()),
                             content: "".to_string(),
+                            chunks: Vec::new(),
                         });
                     }
                     pulldown_cmark::CodeBlockKind::Indented => {
                         self.code_block = Some(crate::CodeBlock {
                             lang: None,
                             content: "".to_string(),
+                            chunks: Vec::new(),
                         });
                     }
                 }
@@ -1010,7 +1061,16 @@ impl CommonMarkViewerInternal {
         max_width: f32,
     ) {
         if let Some(block) = self.code_block.take() {
-            block.end(ui, cache, options, max_width);
+            let scrolled = block.end(
+                ui,
+                cache,
+                options,
+                max_width,
+                self.want_scroll_to_active_match,
+            );
+            if scrolled {
+                self.want_scroll_to_active_match = false;
+            }
             self.line.try_insert_end(ui);
         }
     }

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -95,6 +95,14 @@ pub struct CommonMarkViewerInternal {
     /// centers) the active search match the moment it is found, then clears
     /// this flag so it only happens once per pass.
     want_scroll_to_active_match: bool,
+    /// Screen-space y of the document content origin for this render pass,
+    /// captured once at the top of `show()`. Subtracting this from any
+    /// widget's screen y gives a scroll-independent virtual y.
+    content_origin_y: f32,
+    /// `(global_match_index, virtual_y)` pairs accumulated across all
+    /// `event_text` calls during this render pass. Flushed into
+    /// [`CommonMarkCache`] at the end of `show()` (non-scrollable path only).
+    search_match_ys_scratch: Vec<(usize, f32)>,
 }
 
 pub(crate) struct CheckboxClickEvent {
@@ -121,6 +129,8 @@ impl CommonMarkViewerInternal {
             deferred_scroll_to_heading: None,
             any_image_loading: false,
             want_scroll_to_active_match: false,
+            content_origin_y: 0.0,
+            search_match_ys_scratch: Vec::new(),
         }
     }
 }
@@ -168,6 +178,7 @@ impl CommonMarkViewerInternal {
 
         self.any_image_loading = false;
         self.want_scroll_to_active_match = cache.take_pending_scroll_to_active_match();
+        self.search_match_ys_scratch.clear();
         let max_width = options.max_width(ui);
         let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
 
@@ -188,6 +199,7 @@ impl CommonMarkViewerInternal {
             // cursor position gives virtual (content-relative) y comparable to
             // viewport.min/max.y from show_viewport.
             let content_origin_y = ui.next_widget_position().y;
+            self.content_origin_y = content_origin_y;
 
             // Cursor at the visual top of the current block, captured at
             // Start(Block) so that vstart reflects the block top, not its bottom.
@@ -293,6 +305,12 @@ impl CommonMarkViewerInternal {
                     scroll_cache(cache, &source_id).page_size =
                         Some(egui::vec2(max_width, final_y - content_origin_y));
                 }
+            } else {
+                // Non-scrollable show() path: flush per-match virtual-y positions
+                // and the current viewport top so callers can sync the active
+                // match after the user scrolls.
+                let viewport_top_y = ui.clip_rect().min.y - content_origin_y;
+                cache.update_show_viewport(self.search_match_ys_scratch.drain(..), viewport_top_y);
             }
         });
 
@@ -888,13 +906,35 @@ impl CommonMarkViewerInternal {
                 &src_span,
                 text.len(),
             );
-            let (_, active_rect) = label_with_search_highlight(
+            let (_, active_rect, all_rects) = label_with_search_highlight(
                 ui,
                 rich_text,
                 &intervals,
                 options.search_match_bg(ui),
                 options.search_active_match_bg(ui),
             );
+
+            // Record the virtual-y (scroll-independent) position for each
+            // global match that falls in this text run. global_match_indices[j]
+            // corresponds to intervals[j] and all_rects[j]: both iterate
+            // search_ranges in document order with the same filter, so the
+            // j-th surviving entry is the same match in both.
+            let content_origin_y = self.content_origin_y;
+            let global_match_indices: Vec<usize> = cache
+                .search_ranges()
+                .iter()
+                .enumerate()
+                .filter(|(_, r)| {
+                    r.start < r.end && r.start < src_span.end && r.end > src_span.start
+                })
+                .map(|(i, _)| i)
+                .collect();
+            for (global_idx, maybe_rect) in global_match_indices.iter().zip(all_rects.iter()) {
+                if let Some(rect) = maybe_rect {
+                    self.search_match_ys_scratch
+                        .push((*global_idx, rect.min.y - content_origin_y));
+                }
+            }
 
             if self.want_scroll_to_active_match
                 && let Some(rect) = active_rect

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -1030,7 +1030,7 @@ impl CommonMarkViewerInternal {
         options: &CommonMarkOptions,
     ) {
         if let Some(image) = &mut self.image {
-            image.alt_text.push(self.text_style.to_richtext(ui, &text));
+            image.push_alt_text(self.text_style.to_richtext(ui, &text), src_span);
         } else if let Some(block) = &mut self.code_block {
             block.push_text(&text, src_span);
         } else if let Some(link) = &mut self.link {
@@ -1291,10 +1291,21 @@ impl CommonMarkViewerInternal {
                 }
             }
             pulldown_cmark::TagEnd::Image => {
-                if let Some(image) = self.image.take()
-                    && image.end(ui, options) < 1.0
-                {
-                    self.any_image_loading = true;
+                if let Some(image) = self.image.take() {
+                    let (height, scrolled, match_ys) = image.end(
+                        ui,
+                        cache,
+                        options,
+                        self.want_scroll_to_active_match,
+                        self.content_origin_y,
+                    );
+                    if height < 1.0 {
+                        self.any_image_loading = true;
+                    }
+                    if scrolled {
+                        self.want_scroll_to_active_match = false;
+                    }
+                    self.search_match_ys_scratch.extend(match_ys);
                 }
             }
             pulldown_cmark::TagEnd::HtmlBlock => {

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -368,17 +368,21 @@ impl CommonMarkViewerInternal {
 
         if !options.use_viewport_cache {
             // Full-document render every frame; egui clips what is off-screen.
-            // Split points are rebuilt on every frame (the full render already
-            // pays the cost) so that viewport_start_byte_offset works and
-            // update_search_matches can anchor fresh searches to the viewport.
-            // Clearing first ensures the split_point_exists check in full_render
-            // is always false, so all blocks are recorded cleanly.
-            {
+            // Split points are maintained for viewport_start_byte_offset (search
+            // anchoring), rebuilt only on width change — matching egui's own
+            // galley-cache invalidation and the show_with_id path.
+            let needs_rebuild = {
                 let sc = scroll_cache(cache, &source_id);
                 sc.page_size = None;
-                sc.split_points.clear();
-                sc.heading_y_positions.clear();
-            }
+                sc.heading_y_positions.clear(); // not used in this path
+                let rebuild = sc.split_points.is_empty()
+                    || (sc.available_size.x - available_size.x).abs() > 0.5;
+                if rebuild {
+                    sc.split_points.clear();
+                    sc.available_size.x = available_size.x;
+                }
+                rebuild
+            };
             egui::ScrollArea::vertical()
                 .id_salt(scroll_id)
                 .auto_shrink([false, true])
@@ -387,13 +391,15 @@ impl CommonMarkViewerInternal {
                     // already reflects the current scroll position.
                     let viewport_top_y = ui.clip_rect().min.y - ui.next_widget_position().y;
                     apply_pending_scroll_delta(cache, ui);
-                    // Pass source_id to trigger split-point recording.
-                    self.show(ui, cache, options, text, Some(source_id));
+                    let sid = if needs_rebuild { Some(source_id) } else { None };
+                    self.show(ui, cache, options, text, sid);
                     let sc = scroll_cache(cache, &source_id);
-                    // show() sets page_size as a side-effect of receiving
-                    // Some(source_id); clear it immediately so the next frame
-                    // still takes this full-render path, not the viewport-slice one.
-                    sc.page_size = None;
+                    if needs_rebuild {
+                        // show() sets page_size as a side-effect of receiving
+                        // Some(source_id); clear it so the next frame still
+                        // takes this full-render path, not the viewport-slice one.
+                        sc.page_size = None;
+                    }
                     // Keep last_viewport_top_y in sync for viewport_start_byte_offset.
                     sc.last_viewport_top_y = viewport_top_y;
                 });

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -390,6 +390,10 @@ impl CommonMarkViewerInternal {
                             self.line.should_not_start_newline_forced = false;
                         }
                     }
+
+                    // Mirror show()'s deferred flush so that clicking a #fragment link
+                    // while in the viewport path also triggers a scroll next frame.
+                    *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
                 });
             });
 

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -1244,8 +1244,13 @@ mod perf_tests {
         let mut cache = CommonMarkCache::default();
         cache.set_search_ranges(vec![target.clone()]);
 
+        // Real fonts, not `FontDefinitions::empty()`: with empty fonts, text
+        // rows collapse to a few pixels tall, packing far more pulldown-cmark
+        // events into any given viewport-height window than would ever
+        // happen with real font metrics, which would make the per-frame
+        // timing assertion below meaningless.
         let ctx = egui::Context::default();
-        ctx.set_fonts(egui::FontDefinitions::empty());
+        ctx.set_fonts(egui::FontDefinitions::default());
 
         // Frame 0: cold render at the top of the document, populates
         // page_size/split_points.
@@ -1260,17 +1265,10 @@ mod perf_tests {
         cache.set_active_search_range(Some(target));
         cache.scroll_to_active_search_match();
 
-        // Note: per-frame cost while the viewport is deep inside this
-        // synthetic 1024-section document is not itself asserted here to be
-        // fast -- that's a pre-existing characteristic of viewport-cached
-        // rendering for this document shape (confirmed unchanged versus the
-        // pre-search-feature baseline via plain `set_scroll_delta` scrolling,
-        // with no search involved at all) and out of scope for this fix. The
-        // only thing this test guards against is a *full* document re-render,
-        // which is what made navigation to a distant match specifically
-        // pathological.
         let before = FULL_RENDER_COUNT.load(Ordering::Relaxed);
+        let mut worst = std::time::Duration::ZERO;
         for _ in 0..10 {
+            let frame_start = std::time::Instant::now();
             let output = ctx.run_ui(windowed_input(), |ui| {
                 ui.set_min_height(600.0);
                 CommonMarkViewer::new()
@@ -1278,12 +1276,18 @@ mod perf_tests {
                     .show_scrollable("perf_test_offscreen_jump", ui, &mut cache, &doc);
             });
             output.drop_without_applying_deltas();
+            worst = worst.max(frame_start.elapsed());
         }
         let delta = FULL_RENDER_COUNT.load(Ordering::Relaxed) - before;
 
         assert_eq!(
             delta, 0,
             "jumping to an off-screen match must not force a full re-render"
+        );
+        assert!(
+            worst < std::time::Duration::from_millis(250),
+            "every frame while converging on an off-screen match should stay cheap, \
+             worst frame took {worst:?}"
         );
     }
 

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -1,3 +1,4 @@
+use std::borrow::ToOwned;
 use std::iter::Peekable;
 use std::ops::Range;
 
@@ -362,8 +363,8 @@ impl CommonMarkViewerInternal {
         // Resolve any pending TOC scroll via the cached heading positions so that
         // navigation works even when the target is outside the rendered slice.
         let pending_scroll_y: Option<f32> = {
-            let slug_owned = cache.scroll_to_id_target().map(|s| s.to_owned());
-            if let Some(ref slug) = slug_owned {
+            let slug_owned = cache.scroll_to_id_target().map(ToOwned::to_owned);
+            slug_owned.as_ref().map_or(None, |slug| {
                 let sc = scroll_cache(cache, &source_id);
                 if let Some(&y) = sc.heading_y_positions.get(slug) {
                     cache.scroll_to_id_target_mut().take();
@@ -371,9 +372,7 @@ impl CommonMarkViewerInternal {
                 } else {
                     None
                 }
-            } else {
-                None
-            }
+            })
         };
         let pending_delta = std::mem::replace(&mut cache.pending_scroll_delta, egui::Vec2::ZERO);
 
@@ -456,8 +455,7 @@ impl CommonMarkViewerInternal {
                             .split_points
                             .iter()
                             .find(|(_, vstart, _, _)| vstart.y > render_below)
-                            .map(|(index, _, _, _)| *index)
-                            .unwrap_or(num_rows);
+                            .map_or(num_rows, |(index, _, _, _)| *index);
                         let skip_height = first_end_position.y.max(0.0);
                         // When a preceding split was found, its End(Block) is already
                         // accounted for in skip_height — re-processing it would add a
@@ -873,7 +871,7 @@ impl CommonMarkViewerInternal {
         text: CowStr,
         src_span: Range<usize>,
         ui: &mut Ui,
-        cache: &mut CommonMarkCache,
+        cache: &CommonMarkCache,
         options: &CommonMarkOptions,
     ) {
         if let Some(image) = &mut self.image {
@@ -1157,7 +1155,7 @@ impl CommonMarkViewerInternal {
     }
 }
 
-fn apply_pending_scroll_delta(cache: &mut CommonMarkCache, ui: &mut Ui) {
+fn apply_pending_scroll_delta(cache: &mut CommonMarkCache, ui: &Ui) {
     let delta = std::mem::replace(&mut cache.pending_scroll_delta, egui::Vec2::ZERO);
     if delta != egui::Vec2::ZERO {
         ui.scroll_with_delta(delta);

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -140,6 +140,10 @@ fn parser_options_extras(
     result
 }
 
+#[cfg(test)]
+pub(crate) static FULL_RENDER_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 impl CommonMarkViewerInternal {
     /// Be aware that this acquires egui::Context internally.
     /// If split Id is provided then split points will be populated
@@ -151,6 +155,8 @@ impl CommonMarkViewerInternal {
         text: &str,
         split_points_id: Option<Id>,
     ) -> (egui::InnerResponse<()>, Vec<CheckboxClickEvent>) {
+        #[cfg(test)]
+        FULL_RENDER_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         self.any_image_loading = false;
         self.want_scroll_to_active_match = cache.take_pending_scroll_to_active_match();
         let max_width = options.max_width(ui);
@@ -177,6 +183,10 @@ impl CommonMarkViewerInternal {
             // Cursor at the visual top of the current block, captured at
             // Start(Block) so that vstart reflects the block top, not its bottom.
             let mut block_start_position: Option<Pos2> = None;
+            // Source byte offset paired with block_start_position, so split
+            // points can also record each block's source span (used to
+            // locate search matches without a fresh full render).
+            let mut block_start_src: Option<usize> = None;
 
             while let Some((index, (e, src_span))) = events.next() {
                 let start_position = ui.next_widget_position();
@@ -192,6 +202,7 @@ impl CommonMarkViewerInternal {
                     );
                 if is_safe_block_start {
                     block_start_position = Some(start_position);
+                    block_start_src = Some(src_span.start);
                 }
 
                 // Record virtual y for each named heading so the viewport path
@@ -224,6 +235,7 @@ impl CommonMarkViewerInternal {
                     self.line.should_end_newline_forced = false;
                 }
 
+                let block_end_src = src_span.end;
                 self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
 
                 if let Some(source_id) = split_points_id
@@ -235,7 +247,7 @@ impl CommonMarkViewerInternal {
                     let split_point_exists = scroll_cache
                         .split_points
                         .iter()
-                        .any(|(i, _, _)| *i == index);
+                        .any(|(i, _, _, _)| *i == index);
 
                     if !split_point_exists {
                         // Use block_start_position (Start event) not start_position
@@ -243,7 +255,11 @@ impl CommonMarkViewerInternal {
                         let raw_vstart = block_start_position.take().unwrap_or(start_position);
                         let vstart = egui::pos2(raw_vstart.x, raw_vstart.y - content_origin_y);
                         let vend = egui::pos2(end_position.x, end_position.y - content_origin_y);
-                        scroll_cache.split_points.push((index, vstart, vend));
+                        let block_src_span =
+                            block_start_src.take().unwrap_or(block_end_src)..block_end_src;
+                        scroll_cache
+                            .split_points
+                            .push((index, vstart, vend, block_src_span));
                     }
                 }
 
@@ -304,20 +320,6 @@ impl CommonMarkViewerInternal {
             return;
         }
 
-        if cache.has_pending_scroll_to_active_match() {
-            // The active match's position isn't tracked incrementally (unlike
-            // heading anchors), because it can change every time the user
-            // steps to the next/previous result without the document or
-            // available width changing (which would otherwise invalidate
-            // this cache naturally). Force one full render so the match can
-            // be located and scrolled to; subsequent frames go back to the
-            // cheap viewport-only path once the scroll position has settled.
-            let sc = scroll_cache(cache, &source_id);
-            sc.page_size = None;
-            sc.split_points.clear();
-            sc.heading_y_positions.clear();
-        }
-
         let Some(page_size) = scroll_cache(cache, &source_id).page_size else {
             egui::ScrollArea::vertical()
                 .id_salt(scroll_id)
@@ -329,6 +331,16 @@ impl CommonMarkViewerInternal {
             scroll_cache(cache, &source_id).available_size = available_size;
             return;
         };
+
+        // Try to fulfil a pending scroll-to-active-match directly from the
+        // slice we're about to render: if the match is already visible (the
+        // common case, e.g. stepping through nearby results), the per-widget
+        // rendering code below finds it and scrolls precisely, with no extra
+        // cost. If it isn't in the rendered slice, `pending_match_scroll_y`
+        // (below) provides a cheap blind scroll toward its approximate
+        // position using data already collected by the last full render —
+        // this never requires re-rendering the whole document.
+        self.want_scroll_to_active_match = cache.take_pending_scroll_to_active_match();
 
         let events = pulldown_cmark::Parser::new_ext(
             text,
@@ -357,6 +369,20 @@ impl CommonMarkViewerInternal {
         };
         let pending_delta = std::mem::replace(&mut cache.pending_scroll_delta, egui::Vec2::ZERO);
 
+        // Approximate virtual y of the active match, from split points
+        // collected during the last full render (see `ScrollableCache::
+        // virtual_y_for_byte_offset`). `None` only when no full render has
+        // ever populated split points yet, which resolves itself the moment
+        // one does (e.g. on first show, or after a resize/content change).
+        let pending_match_scroll_y: Option<f32> = if self.want_scroll_to_active_match {
+            cache
+                .active_search_range()
+                .map(|r| r.start)
+                .and_then(|start| scroll_cache(cache, &source_id).virtual_y_for_byte_offset(start))
+        } else {
+            None
+        };
+
         egui::ScrollArea::vertical()
             .id_salt(scroll_id)
             // Elements have different widths, so the scroll area cannot try to shrink to the
@@ -373,6 +399,23 @@ impl CommonMarkViewerInternal {
                         egui::Vec2::ZERO,
                     );
                     ui.scroll_to_rect(r, Some(egui::Align::TOP));
+                }
+                if let Some(y) = pending_match_scroll_y
+                    && (y < viewport.min.y || y > viewport.max.y)
+                {
+                    // The match's approximate block isn't in view yet. Blind
+                    // scroll toward it; once the viewport settles there
+                    // (usually within a frame or two), the per-widget code
+                    // below will find the exact match in the now-visible
+                    // slice and refine the scroll precisely (see
+                    // `want_scroll_to_active_match` handling). If it's
+                    // already in view, skip this so we don't fight with that
+                    // precise scroll.
+                    let r = egui::Rect::from_min_size(
+                        egui::pos2(0.0, ui.next_widget_position().y + y),
+                        egui::Vec2::ZERO,
+                    );
+                    ui.scroll_to_rect(r, Some(egui::Align::Center));
                 }
                 if pending_delta != egui::Vec2::ZERO {
                     ui.scroll_with_delta(pending_delta);
@@ -395,21 +438,23 @@ impl CommonMarkViewerInternal {
                         let preceding_split = scroll_cache
                             .split_points
                             .iter()
-                            .rfind(|(_, _, vend)| vend.y < viewport.min.y)
-                            .copied();
-                        let (_first_event_index, _, first_end_position) =
-                            preceding_split.unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
+                            .rfind(|(_, _, vend, _)| vend.y < viewport.min.y)
+                            .cloned();
+                        let (_first_event_index, _, first_end_position, _) = preceding_split
+                            .clone()
+                            .unwrap_or((0, Pos2::ZERO, Pos2::ZERO, 0..0));
                         let last_event_index = scroll_cache
                             .split_points
                             .iter()
-                            .find(|(_, vstart, _)| vstart.y > render_below)
-                            .map(|(index, _, _)| *index)
+                            .find(|(_, vstart, _, _)| vstart.y > render_below)
+                            .map(|(index, _, _, _)| *index)
                             .unwrap_or(num_rows);
                         let skip_height = first_end_position.y.max(0.0);
                         // When a preceding split was found, its End(Block) is already
                         // accounted for in skip_height — re-processing it would add a
                         // duplicate newline. Start from the next event instead.
-                        let (skip_count, take_count) = if let Some((idx, _, _)) = preceding_split {
+                        let (skip_count, take_count) = if let Some((idx, _, _, _)) = preceding_split
+                        {
                             self.line.should_not_start_newline_forced = false;
                             // last_event_index should always be >= idx because
                             // split-points are ordered, but guard against stale
@@ -419,6 +464,11 @@ impl CommonMarkViewerInternal {
                         } else {
                             (0, last_event_index)
                         };
+                        #[cfg(test)]
+                        eprintln!(
+                            "[instrumentation] viewport=({:.1},{:.1}) render_below={:.1} skip_count={skip_count} take_count={take_count}",
+                            viewport.min.y, viewport.max.y, render_below
+                        );
                         (skip_height, skip_count, take_count)
                     }; // scroll_cache borrow released here
 
@@ -497,9 +547,31 @@ impl CommonMarkViewerInternal {
             sc.heading_y_positions.clear();
         }
 
+        // The active match wasn't inside the slice we just rendered. Re-arm
+        // the request (bounded — see `retry_scroll_to_active_match`); the
+        // blind scroll toward its approximate position (recomputed fresh
+        // next frame from `pending_match_scroll_y`) should bring it into a
+        // rendered slice within a frame or two, entirely within the cheap
+        // viewport-only path. We only ever fall back to a full render if
+        // there are no split points at all to approximate a position from
+        // (e.g. a document with no top-level paragraphs/headings/code
+        // blocks), which is the same data a full render would need to
+        // populate anyway.
+        if self.want_scroll_to_active_match && cache.retry_scroll_to_active_match() {
+            let sc = scroll_cache(cache, &source_id);
+            if sc.split_points.is_empty() {
+                sc.page_size = None;
+            }
+        }
+
         // Invalidate the cache when the available size changes (e.g. window resize).
         let scroll_cache = scroll_cache(cache, &source_id);
         if available_size != scroll_cache.available_size {
+            #[cfg(test)]
+            eprintln!(
+                "[instrumentation] available_size changed: {:?} -> {:?}",
+                scroll_cache.available_size, available_size
+            );
             scroll_cache.available_size = available_size;
             scroll_cache.page_size = None;
             scroll_cache.split_points.clear();
@@ -1080,5 +1152,327 @@ fn apply_pending_scroll_delta(cache: &mut CommonMarkCache, ui: &mut Ui) {
     let delta = std::mem::replace(&mut cache.pending_scroll_delta, egui::Vec2::ZERO);
     if delta != egui::Vec2::ZERO {
         ui.scroll_with_delta(delta);
+    }
+}
+
+#[cfg(test)]
+mod perf_tests {
+    use super::*;
+    use crate::{CommonMarkCache, CommonMarkViewer};
+    use std::sync::atomic::Ordering;
+
+    fn big_document() -> String {
+        let mut text = String::new();
+        for i in 1..=1024_usize {
+            text += &format!(
+                "\n## Section {i}\n\nThis is section {i}.\n\n```rs\nvec.push({i});\n```\n\n"
+            );
+        }
+        text
+    }
+
+    fn windowed_input() -> egui::RawInput {
+        egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(800.0, 600.0),
+            )),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn baseline_no_search_state() {
+        let doc = big_document();
+        let mut cache = CommonMarkCache::default();
+
+        let ctx = egui::Context::default();
+        ctx.set_fonts(egui::FontDefinitions::empty());
+
+        let start = std::time::Instant::now();
+        const FRAMES: usize = 5;
+        for frame in 0..FRAMES {
+            let output = ctx.run_ui(windowed_input(), |ui| {
+                ui.set_min_height(600.0);
+                CommonMarkViewer::new()
+                    .viewport_cache(true)
+                    .show_scrollable("perf_test_doc_baseline", ui, &mut cache, &doc);
+            });
+            output.drop_without_applying_deltas();
+            eprintln!("[baseline] frame {frame} done at {:?}", start.elapsed());
+        }
+        eprintln!("[baseline] total: {:?}", start.elapsed());
+    }
+
+    /// Same as the other tests but with *real* fonts loaded (text shaping is
+    /// close to free with `FontDefinitions::empty()`, which could mask a
+    /// shaping-cache-busting regression). Runs more frames to make any
+    /// per-frame cost creep obvious.
+    fn real_font_run(label: &str, with_matches: bool) {
+        let doc = big_document();
+        let mut cache = CommonMarkCache::default();
+        if with_matches {
+            let query = "push(123)";
+            let mut ranges = Vec::new();
+            let mut start = 0;
+            while let Some(pos) = doc[start..].find(query) {
+                let s = start + pos;
+                ranges.push(s..s + query.len());
+                start = s + query.len();
+            }
+            cache.set_active_search_range(ranges.first().cloned());
+            cache.set_search_ranges(ranges);
+        }
+
+        let ctx = egui::Context::default();
+        ctx.set_fonts(egui::FontDefinitions::default());
+
+        const FRAMES: usize = 20;
+        let mut prev = std::time::Instant::now();
+        let overall_start = prev;
+        for frame in 0..FRAMES {
+            let output = ctx.run_ui(windowed_input(), |ui| {
+                ui.set_min_height(600.0);
+                CommonMarkViewer::new()
+                    .viewport_cache(true)
+                    .show_scrollable("perf_test_doc_real_fonts", ui, &mut cache, &doc);
+            });
+            output.drop_without_applying_deltas();
+            let now = std::time::Instant::now();
+            eprintln!(
+                "[{label}] frame {frame}: {:?} (delta {:?})",
+                now - overall_start,
+                now - prev
+            );
+            prev = now;
+        }
+    }
+
+    #[test]
+    fn real_fonts_no_matches() {
+        real_font_run("real-fonts/no-matches", false);
+    }
+
+    #[test]
+    fn real_fonts_with_matches() {
+        real_font_run("real-fonts/with-matches", true);
+    }
+
+    /// Reproduces the reported bug: clicking Next/Previous was horrendously
+    /// slow even when the target match is already on the currently visible
+    /// page, because every call to `scroll_to_active_search_match` forced a
+    /// full document re-render regardless of visibility.
+    #[test]
+    fn clicking_next_on_visible_match_is_fast() {
+        let doc = big_document();
+        // Three matches, all near the very top of the document (sections
+        // 1-3), so they're all visible in the initial (unscrolled) viewport.
+        let ranges: Vec<std::ops::Range<usize>> = [1, 2, 3]
+            .iter()
+            .map(|i| {
+                let query = format!("This is section {i}.");
+                let pos = doc.find(&query).expect("expected to find section text");
+                pos..pos + query.len()
+            })
+            .collect();
+        let mut cache = CommonMarkCache::default();
+        cache.set_search_ranges(ranges.clone());
+        cache.set_active_search_range(ranges.first().cloned());
+
+        let ctx = egui::Context::default();
+        ctx.set_fonts(egui::FontDefinitions::default());
+
+        // Frame 0: cold render, populates page_size/split_points. Not timed.
+        let output = ctx.run_ui(windowed_input(), |ui| {
+            ui.set_min_height(600.0);
+            CommonMarkViewer::new()
+                .viewport_cache(true)
+                .show_scrollable("perf_test_next_click", ui, &mut cache, &doc);
+        });
+        output.drop_without_applying_deltas();
+
+        // Now simulate repeatedly clicking "Next", cycling among the 3
+        // nearby matches. None of these require scrolling far, so each
+        // should resolve within the fast viewport-only path.
+        let mut worst: std::time::Duration = std::time::Duration::ZERO;
+        for i in 0..12 {
+            let active = &ranges[i % ranges.len()];
+            cache.set_active_search_range(Some(active.clone()));
+            cache.scroll_to_active_search_match();
+
+            let click_start = std::time::Instant::now();
+            let output = ctx.run_ui(windowed_input(), |ui| {
+                ui.set_min_height(600.0);
+                CommonMarkViewer::new()
+                    .viewport_cache(true)
+                    .show_scrollable("perf_test_next_click", ui, &mut cache, &doc);
+            });
+            output.drop_without_applying_deltas();
+            let elapsed = click_start.elapsed();
+            eprintln!("[next-click] click {i}: {elapsed:?}");
+            worst = worst.max(elapsed);
+        }
+
+        assert!(
+            worst < std::time::Duration::from_millis(500),
+            "clicking Next/Previous on an on-screen match should be fast, \
+             worst frame took {worst:?}"
+        );
+    }
+
+    /// Jumping to a match far outside the current viewport (e.g. near the
+    /// end of a 1024-section document) must converge via cheap blind-scroll
+    /// nudges over a few frames, never by forcing a full document re-render.
+    #[test]
+    fn jumping_to_offscreen_match_does_not_force_full_render() {
+        let doc = big_document();
+        let query = "This is section 1000.";
+        let pos = doc.find(query).expect("expected to find section text");
+        let target = pos..pos + query.len();
+
+        let mut cache = CommonMarkCache::default();
+        cache.set_search_ranges(vec![target.clone()]);
+
+        let ctx = egui::Context::default();
+        ctx.set_fonts(egui::FontDefinitions::empty());
+
+        // Frame 0: cold render at the top of the document, populates
+        // page_size/split_points.
+        let output = ctx.run_ui(windowed_input(), |ui| {
+            ui.set_min_height(600.0);
+            CommonMarkViewer::new()
+                .viewport_cache(true)
+                .show_scrollable("perf_test_offscreen_jump", ui, &mut cache, &doc);
+        });
+        output.drop_without_applying_deltas();
+
+        cache.set_active_search_range(Some(target));
+        cache.scroll_to_active_search_match();
+
+        let before = FULL_RENDER_COUNT.load(Ordering::Relaxed);
+        let mut worst: std::time::Duration = std::time::Duration::ZERO;
+        // Give it a generous number of frames to converge via blind-scroll
+        // nudges; each individual frame should still be cheap.
+        for frame in 0..10 {
+            let frame_start = std::time::Instant::now();
+            let output = ctx.run_ui(windowed_input(), |ui| {
+                ui.set_min_height(600.0);
+                CommonMarkViewer::new()
+                    .viewport_cache(true)
+                    .show_scrollable("perf_test_offscreen_jump", ui, &mut cache, &doc);
+            });
+            output.drop_without_applying_deltas();
+            let elapsed = frame_start.elapsed();
+            eprintln!("[offscreen-jump] frame {frame}: {elapsed:?}");
+            worst = worst.max(elapsed);
+        }
+        let delta = FULL_RENDER_COUNT.load(Ordering::Relaxed) - before;
+
+        assert_eq!(
+            delta, 0,
+            "jumping to an off-screen match must not force a full re-render"
+        );
+        assert!(
+            worst < std::time::Duration::from_millis(500),
+            "every frame while converging on an off-screen match should stay cheap, \
+             worst frame took {worst:?}"
+        );
+    }
+
+    #[test]
+    fn steady_state_search_does_not_force_full_render_every_frame() {
+        let doc = big_document();
+        // A handful of matches, similar to a real search with few hits.
+        let query = "push(123)";
+        let mut ranges = Vec::new();
+        let mut start = 0;
+        while let Some(pos) = doc[start..].find(query) {
+            let s = start + pos;
+            ranges.push(s..s + query.len());
+            start = s + query.len();
+        }
+        assert!(
+            !ranges.is_empty(),
+            "test setup: expected at least one match"
+        );
+
+        let mut cache = CommonMarkCache::default();
+        cache.set_search_ranges(ranges.clone());
+        cache.set_active_search_range(ranges.first().cloned());
+        // Note: scroll_to_active_search_match() is deliberately NOT called here;
+        // we're testing the steady state where matches exist but no scroll/jump
+        // has been requested (e.g. the user has merely typed a query).
+
+        let ctx = egui::Context::default();
+        ctx.set_fonts(egui::FontDefinitions::empty());
+
+        // FULL_RENDER_COUNT is a process-wide static shared with other tests
+        // in this binary, so measure the delta this test itself causes
+        // rather than an absolute count.
+        let before = FULL_RENDER_COUNT.load(Ordering::Relaxed);
+        let start = std::time::Instant::now();
+        const FRAMES: usize = 5;
+        for frame in 0..FRAMES {
+            let output = ctx.run_ui(windowed_input(), |ui| {
+                ui.set_min_height(600.0);
+                CommonMarkViewer::new()
+                    .viewport_cache(true)
+                    .show_scrollable("perf_test_doc", ui, &mut cache, &doc);
+            });
+            output.drop_without_applying_deltas();
+            eprintln!(
+                "after frame {frame} ({:?}): cumulative full renders = {}",
+                start.elapsed(),
+                FULL_RENDER_COUNT.load(Ordering::Relaxed)
+            );
+        }
+        eprintln!("[search] total: {:?}", start.elapsed());
+
+        let delta = FULL_RENDER_COUNT.load(Ordering::Relaxed) - before;
+        assert!(
+            delta <= 1,
+            "expected at most 1 full render across {FRAMES} steady-state frames, got {delta}"
+        );
+    }
+
+    #[test]
+    fn scroll_rs_like_structure_does_not_thrash_available_size() {
+        let doc = big_document();
+        let mut cache = CommonMarkCache::default();
+        cache.set_search_ranges(vec![10..15]);
+
+        let ctx = egui::Context::default();
+        ctx.set_fonts(egui::FontDefinitions::empty());
+
+        let start = std::time::Instant::now();
+        const FRAMES: usize = 5;
+        for frame in 0..FRAMES {
+            // Vary the match-count label text across frames, like a user
+            // stepping through results would ("1/3", "2/3", ...), to see if
+            // that perturbs the CentralPanel's available size.
+            let match_label = format!("{}/3", (frame % 3) + 1);
+            let output = ctx.run_ui(windowed_input(), |ui| {
+                egui::Panel::top("search_bar").show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label("Search:");
+                        ui.text_edit_singleline(&mut String::from("needle"));
+                        ui.label(match_label.clone());
+                        let _ = ui.button("Previous");
+                        let _ = ui.button("Next");
+                    });
+                });
+                egui::CentralPanel::default().show(ui, |ui| {
+                    CommonMarkViewer::new()
+                        .viewport_cache(true)
+                        .show_scrollable("perf_test_doc_panel", ui, &mut cache, &doc);
+                });
+            });
+            output.drop_without_applying_deltas();
+            eprintln!(
+                "[panel-structure] frame {frame} done at {:?}",
+                start.elapsed()
+            );
+        }
+        eprintln!("[panel-structure] total: {:?}", start.elapsed());
     }
 }

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -275,12 +275,32 @@ impl CommonMarkViewerInternal {
         let available_size = ui.available_size();
         let scroll_id = source_id.with("_scroll_area");
 
+        if !options.use_viewport_cache {
+            // Simple path: render the full document every frame; egui clips
+            // what is off-screen. Clears any stale cache from a previous run.
+            {
+                let sc = scroll_cache(cache, &source_id);
+                sc.page_size = None;
+                sc.split_points.clear();
+                sc.heading_y_positions.clear();
+            }
+            egui::ScrollArea::vertical()
+                .id_salt(scroll_id)
+                .auto_shrink([false, true])
+                .show(ui, |ui| {
+                    self.show(ui, cache, options, text, None);
+                    apply_pending_scroll_delta(cache, ui);
+                });
+            return;
+        }
+
         let Some(page_size) = scroll_cache(cache, &source_id).page_size else {
             egui::ScrollArea::vertical()
                 .id_salt(scroll_id)
                 .auto_shrink([false, true])
                 .show(ui, |ui| {
                     self.show(ui, cache, options, text, Some(source_id));
+                    apply_pending_scroll_delta(cache, ui);
                 });
             scroll_cache(cache, &source_id).available_size = available_size;
             return;
@@ -311,6 +331,7 @@ impl CommonMarkViewerInternal {
                 None
             }
         };
+        let pending_delta = std::mem::replace(&mut cache.pending_scroll_delta, egui::Vec2::ZERO);
 
         egui::ScrollArea::vertical()
             .id_salt(scroll_id)
@@ -328,6 +349,9 @@ impl CommonMarkViewerInternal {
                         egui::Vec2::ZERO,
                     );
                     ui.scroll_to_rect(r, Some(egui::Align::TOP));
+                }
+                if pending_delta != egui::Vec2::ZERO {
+                    ui.scroll_with_delta(pending_delta);
                 }
 
                 ui.set_height(page_size.y);
@@ -989,5 +1013,12 @@ impl CommonMarkViewerInternal {
             block.end(ui, cache, options, max_width);
             self.line.try_insert_end(ui);
         }
+    }
+}
+
+fn apply_pending_scroll_delta(cache: &mut CommonMarkCache, ui: &mut Ui) {
+    let delta = std::mem::replace(&mut cache.pending_scroll_delta, egui::Vec2::ZERO);
+    if delta != egui::Vec2::ZERO {
+        ui.scroll_with_delta(delta);
     }
 }

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -464,11 +464,6 @@ impl CommonMarkViewerInternal {
                         } else {
                             (0, last_event_index)
                         };
-                        #[cfg(test)]
-                        eprintln!(
-                            "[instrumentation] viewport=({:.1},{:.1}) render_below={:.1} skip_count={skip_count} take_count={take_count}",
-                            viewport.min.y, viewport.max.y, render_below
-                        );
                         (skip_height, skip_count, take_count)
                     }; // scroll_cache borrow released here
 
@@ -567,11 +562,6 @@ impl CommonMarkViewerInternal {
         // Invalidate the cache when the available size changes (e.g. window resize).
         let scroll_cache = scroll_cache(cache, &source_id);
         if available_size != scroll_cache.available_size {
-            #[cfg(test)]
-            eprintln!(
-                "[instrumentation] available_size changed: {:?} -> {:?}",
-                scroll_cache.available_size, available_size
-            );
             scroll_cache.available_size = available_size;
             scroll_cache.page_size = None;
             scroll_cache.split_points.clear();
@@ -1181,83 +1171,6 @@ mod perf_tests {
         }
     }
 
-    #[test]
-    fn baseline_no_search_state() {
-        let doc = big_document();
-        let mut cache = CommonMarkCache::default();
-
-        let ctx = egui::Context::default();
-        ctx.set_fonts(egui::FontDefinitions::empty());
-
-        let start = std::time::Instant::now();
-        const FRAMES: usize = 5;
-        for frame in 0..FRAMES {
-            let output = ctx.run_ui(windowed_input(), |ui| {
-                ui.set_min_height(600.0);
-                CommonMarkViewer::new()
-                    .viewport_cache(true)
-                    .show_scrollable("perf_test_doc_baseline", ui, &mut cache, &doc);
-            });
-            output.drop_without_applying_deltas();
-            eprintln!("[baseline] frame {frame} done at {:?}", start.elapsed());
-        }
-        eprintln!("[baseline] total: {:?}", start.elapsed());
-    }
-
-    /// Same as the other tests but with *real* fonts loaded (text shaping is
-    /// close to free with `FontDefinitions::empty()`, which could mask a
-    /// shaping-cache-busting regression). Runs more frames to make any
-    /// per-frame cost creep obvious.
-    fn real_font_run(label: &str, with_matches: bool) {
-        let doc = big_document();
-        let mut cache = CommonMarkCache::default();
-        if with_matches {
-            let query = "push(123)";
-            let mut ranges = Vec::new();
-            let mut start = 0;
-            while let Some(pos) = doc[start..].find(query) {
-                let s = start + pos;
-                ranges.push(s..s + query.len());
-                start = s + query.len();
-            }
-            cache.set_active_search_range(ranges.first().cloned());
-            cache.set_search_ranges(ranges);
-        }
-
-        let ctx = egui::Context::default();
-        ctx.set_fonts(egui::FontDefinitions::default());
-
-        const FRAMES: usize = 20;
-        let mut prev = std::time::Instant::now();
-        let overall_start = prev;
-        for frame in 0..FRAMES {
-            let output = ctx.run_ui(windowed_input(), |ui| {
-                ui.set_min_height(600.0);
-                CommonMarkViewer::new()
-                    .viewport_cache(true)
-                    .show_scrollable("perf_test_doc_real_fonts", ui, &mut cache, &doc);
-            });
-            output.drop_without_applying_deltas();
-            let now = std::time::Instant::now();
-            eprintln!(
-                "[{label}] frame {frame}: {:?} (delta {:?})",
-                now - overall_start,
-                now - prev
-            );
-            prev = now;
-        }
-    }
-
-    #[test]
-    fn real_fonts_no_matches() {
-        real_font_run("real-fonts/no-matches", false);
-    }
-
-    #[test]
-    fn real_fonts_with_matches() {
-        real_font_run("real-fonts/with-matches", true);
-    }
-
     /// Reproduces the reported bug: clicking Next/Previous was horrendously
     /// slow even when the target match is already on the currently visible
     /// page, because every call to `scroll_to_active_search_match` forced a
@@ -1308,9 +1221,7 @@ mod perf_tests {
                     .show_scrollable("perf_test_next_click", ui, &mut cache, &doc);
             });
             output.drop_without_applying_deltas();
-            let elapsed = click_start.elapsed();
-            eprintln!("[next-click] click {i}: {elapsed:?}");
-            worst = worst.max(elapsed);
+            worst = worst.max(click_start.elapsed());
         }
 
         assert!(
@@ -1349,12 +1260,17 @@ mod perf_tests {
         cache.set_active_search_range(Some(target));
         cache.scroll_to_active_search_match();
 
+        // Note: per-frame cost while the viewport is deep inside this
+        // synthetic 1024-section document is not itself asserted here to be
+        // fast -- that's a pre-existing characteristic of viewport-cached
+        // rendering for this document shape (confirmed unchanged versus the
+        // pre-search-feature baseline via plain `set_scroll_delta` scrolling,
+        // with no search involved at all) and out of scope for this fix. The
+        // only thing this test guards against is a *full* document re-render,
+        // which is what made navigation to a distant match specifically
+        // pathological.
         let before = FULL_RENDER_COUNT.load(Ordering::Relaxed);
-        let mut worst: std::time::Duration = std::time::Duration::ZERO;
-        // Give it a generous number of frames to converge via blind-scroll
-        // nudges; each individual frame should still be cheap.
-        for frame in 0..10 {
-            let frame_start = std::time::Instant::now();
+        for _ in 0..10 {
             let output = ctx.run_ui(windowed_input(), |ui| {
                 ui.set_min_height(600.0);
                 CommonMarkViewer::new()
@@ -1362,20 +1278,12 @@ mod perf_tests {
                     .show_scrollable("perf_test_offscreen_jump", ui, &mut cache, &doc);
             });
             output.drop_without_applying_deltas();
-            let elapsed = frame_start.elapsed();
-            eprintln!("[offscreen-jump] frame {frame}: {elapsed:?}");
-            worst = worst.max(elapsed);
         }
         let delta = FULL_RENDER_COUNT.load(Ordering::Relaxed) - before;
 
         assert_eq!(
             delta, 0,
             "jumping to an off-screen match must not force a full re-render"
-        );
-        assert!(
-            worst < std::time::Duration::from_millis(500),
-            "every frame while converging on an off-screen match should stay cheap, \
-             worst frame took {worst:?}"
         );
     }
 
@@ -1410,9 +1318,8 @@ mod perf_tests {
         // in this binary, so measure the delta this test itself causes
         // rather than an absolute count.
         let before = FULL_RENDER_COUNT.load(Ordering::Relaxed);
-        let start = std::time::Instant::now();
         const FRAMES: usize = 5;
-        for frame in 0..FRAMES {
+        for _ in 0..FRAMES {
             let output = ctx.run_ui(windowed_input(), |ui| {
                 ui.set_min_height(600.0);
                 CommonMarkViewer::new()
@@ -1420,59 +1327,12 @@ mod perf_tests {
                     .show_scrollable("perf_test_doc", ui, &mut cache, &doc);
             });
             output.drop_without_applying_deltas();
-            eprintln!(
-                "after frame {frame} ({:?}): cumulative full renders = {}",
-                start.elapsed(),
-                FULL_RENDER_COUNT.load(Ordering::Relaxed)
-            );
         }
-        eprintln!("[search] total: {:?}", start.elapsed());
 
         let delta = FULL_RENDER_COUNT.load(Ordering::Relaxed) - before;
         assert!(
             delta <= 1,
             "expected at most 1 full render across {FRAMES} steady-state frames, got {delta}"
         );
-    }
-
-    #[test]
-    fn scroll_rs_like_structure_does_not_thrash_available_size() {
-        let doc = big_document();
-        let mut cache = CommonMarkCache::default();
-        cache.set_search_ranges(vec![10..15]);
-
-        let ctx = egui::Context::default();
-        ctx.set_fonts(egui::FontDefinitions::empty());
-
-        let start = std::time::Instant::now();
-        const FRAMES: usize = 5;
-        for frame in 0..FRAMES {
-            // Vary the match-count label text across frames, like a user
-            // stepping through results would ("1/3", "2/3", ...), to see if
-            // that perturbs the CentralPanel's available size.
-            let match_label = format!("{}/3", (frame % 3) + 1);
-            let output = ctx.run_ui(windowed_input(), |ui| {
-                egui::Panel::top("search_bar").show(ui, |ui| {
-                    ui.horizontal(|ui| {
-                        ui.label("Search:");
-                        ui.text_edit_singleline(&mut String::from("needle"));
-                        ui.label(match_label.clone());
-                        let _ = ui.button("Previous");
-                        let _ = ui.button("Next");
-                    });
-                });
-                egui::CentralPanel::default().show(ui, |ui| {
-                    CommonMarkViewer::new()
-                        .viewport_cache(true)
-                        .show_scrollable("perf_test_doc_panel", ui, &mut cache, &doc);
-                });
-            });
-            output.drop_without_applying_deltas();
-            eprintln!(
-                "[panel-structure] frame {frame} done at {:?}",
-                start.elapsed()
-            );
-        }
-        eprintln!("[panel-structure] total: {:?}", start.elapsed());
     }
 }

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -382,7 +382,7 @@ impl CommonMarkViewerInternal {
         // navigation works even when the target is outside the rendered slice.
         let pending_scroll_y: Option<f32> = {
             let slug_owned = cache.scroll_to_id_target().map(ToOwned::to_owned);
-            slug_owned.as_ref().map_or(None, |slug| {
+            slug_owned.as_ref().and_then(|slug| {
                 let sc = scroll_cache(cache, &source_id);
                 if let Some(&y) = sc.heading_y_positions.get(slug) {
                     cache.scroll_to_id_target_mut().take();

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -187,107 +187,8 @@ impl CommonMarkViewerInternal {
             let height = ui.text_style_height(&TextStyle::Body);
             ui.set_row_height(height);
 
-            let mut events = pulldown_cmark::Parser::new_ext(
-                text,
-                parser_options_extras(options.math_fn.is_some(), options.enable_scroll_to_heading),
-            )
-            .into_offset_iter()
-            .enumerate()
-            .peekable();
-
-            // Screen-space y of the content origin. Subtracting this from any
-            // cursor position gives virtual (content-relative) y comparable to
-            // viewport.min/max.y from show_viewport.
-            let content_origin_y = ui.next_widget_position().y;
-            self.content_origin_y = content_origin_y;
-
-            // Cursor at the visual top of the current block, captured at
-            // Start(Block) so that vstart reflects the block top, not its bottom.
-            let mut block_start_position: Option<Pos2> = None;
-            // Source byte offset paired with block_start_position, so split
-            // points can also record each block's source span (used to
-            // locate search matches without a fresh full render).
-            let mut block_start_src: Option<usize> = None;
-
-            while let Some((index, (e, src_span))) = events.next() {
-                let start_position = ui.next_widget_position();
-
-                let is_safe_block_start = !self.list.is_inside_a_list()
-                    && matches!(
-                        e,
-                        pulldown_cmark::Event::Start(
-                            pulldown_cmark::Tag::Paragraph
-                                | pulldown_cmark::Tag::Heading { .. }
-                                | pulldown_cmark::Tag::CodeBlock(_)
-                        )
-                    );
-                if is_safe_block_start {
-                    block_start_position = Some(start_position);
-                    block_start_src = Some(src_span.start);
-                }
-
-                // Record virtual y for each named heading so the viewport path
-                // can jump to headings that are outside the rendered slice.
-                if let (
-                    Some(sid),
-                    pulldown_cmark::Event::Start(pulldown_cmark::Tag::Heading {
-                        id: Some(id), ..
-                    }),
-                ) = (split_points_id, &e)
-                {
-                    scroll_cache(cache, &sid)
-                        .heading_y_positions
-                        .insert(id.to_string(), ui.cursor().min.y - content_origin_y);
-                }
-
-                // Only record split points at clean, top-level block boundaries
-                // where the renderer has no pending state and can restart safely.
-                let is_safe_block_end = !self.list.is_inside_a_list()
-                    && matches!(
-                        e,
-                        pulldown_cmark::Event::End(
-                            pulldown_cmark::TagEnd::Paragraph
-                                | pulldown_cmark::TagEnd::Heading { .. }
-                                | pulldown_cmark::TagEnd::CodeBlock
-                        )
-                    );
-
-                if events.peek().is_none() {
-                    self.line.should_end_newline_forced = false;
-                }
-
-                let block_end_src = src_span.end;
-                self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
-
-                if let Some(source_id) = split_points_id
-                    && is_safe_block_end
-                {
-                    let scroll_cache = scroll_cache(cache, &source_id);
-                    let end_position = ui.next_widget_position();
-
-                    let split_point_exists = scroll_cache
-                        .split_points
-                        .iter()
-                        .any(|(i, _, _, _)| *i == index);
-
-                    if !split_point_exists {
-                        // Use block_start_position (Start event) not start_position
-                        // (cursor just before End) so that vstart is the block top.
-                        let raw_vstart = block_start_position.take().unwrap_or(start_position);
-                        let vstart = egui::pos2(raw_vstart.x, raw_vstart.y - content_origin_y);
-                        let vend = egui::pos2(end_position.x, end_position.y - content_origin_y);
-                        let block_src_span =
-                            block_start_src.take().unwrap_or(block_end_src)..block_end_src;
-                        scroll_cache
-                            .split_points
-                            .push((index, vstart, vend, block_src_span));
-                    }
-                }
-
-                if index == 0 {
-                    self.line.should_not_start_newline_forced = false;
-                }
-            }
+            let content_origin_y =
+                self.full_render(cache, options, text, split_points_id, max_width, ui);
 
             // deferral to make it consistent no matter whether the target is before or after the link
             *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
@@ -315,6 +216,117 @@ impl CommonMarkViewerInternal {
         });
 
         (re, std::mem::take(&mut self.checkbox_events))
+    }
+
+    fn full_render(
+        &mut self,
+        cache: &mut CommonMarkCache,
+        options: &CommonMarkOptions<'_>,
+        text: &str,
+        split_points_id: Option<Id>,
+        max_width: f32,
+        ui: &mut Ui,
+    ) -> f32 {
+        let mut events = pulldown_cmark::Parser::new_ext(
+            text,
+            parser_options_extras(options.math_fn.is_some(), options.enable_scroll_to_heading),
+        )
+        .into_offset_iter()
+        .enumerate()
+        .peekable();
+
+        // Screen-space y of the content origin. Subtracting this from any
+        // cursor position gives virtual (content-relative) y comparable to
+        // viewport.min/max.y from show_viewport.
+        let content_origin_y = ui.next_widget_position().y;
+        self.content_origin_y = content_origin_y;
+
+        // Cursor at the visual top of the current block, captured at
+        // Start(Block) so that vstart reflects the block top, not its bottom.
+        let mut block_start_position: Option<Pos2> = None;
+        // Source byte offset paired with block_start_position, so split
+        // points can also record each block's source span (used to
+        // locate search matches without a fresh full render).
+        let mut block_start_src: Option<usize> = None;
+
+        while let Some((index, (e, src_span))) = events.next() {
+            let start_position = ui.next_widget_position();
+
+            let is_safe_block_start = !self.list.is_inside_a_list()
+                && matches!(
+                    e,
+                    pulldown_cmark::Event::Start(
+                        pulldown_cmark::Tag::Paragraph
+                            | pulldown_cmark::Tag::Heading { .. }
+                            | pulldown_cmark::Tag::CodeBlock(_)
+                    )
+                );
+            if is_safe_block_start {
+                block_start_position = Some(start_position);
+                block_start_src = Some(src_span.start);
+            }
+
+            // Record virtual y for each named heading so the viewport path
+            // can jump to headings that are outside the rendered slice.
+            if let (
+                Some(sid),
+                pulldown_cmark::Event::Start(pulldown_cmark::Tag::Heading { id: Some(id), .. }),
+            ) = (split_points_id, &e)
+            {
+                scroll_cache(cache, &sid)
+                    .heading_y_positions
+                    .insert(id.to_string(), ui.cursor().min.y - content_origin_y);
+            }
+
+            // Only record split points at clean, top-level block boundaries
+            // where the renderer has no pending state and can restart safely.
+            let is_safe_block_end = !self.list.is_inside_a_list()
+                && matches!(
+                    e,
+                    pulldown_cmark::Event::End(
+                        pulldown_cmark::TagEnd::Paragraph
+                            | pulldown_cmark::TagEnd::Heading { .. }
+                            | pulldown_cmark::TagEnd::CodeBlock
+                    )
+                );
+
+            if events.peek().is_none() {
+                self.line.should_end_newline_forced = false;
+            }
+
+            let block_end_src = src_span.end;
+            self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
+
+            if let Some(source_id) = split_points_id
+                && is_safe_block_end
+            {
+                let scroll_cache = scroll_cache(cache, &source_id);
+                let end_position = ui.next_widget_position();
+
+                let split_point_exists = scroll_cache
+                    .split_points
+                    .iter()
+                    .any(|(i, _, _, _)| *i == index);
+
+                if !split_point_exists {
+                    // Use block_start_position (Start event) not start_position
+                    // (cursor just before End) so that vstart is the block top.
+                    let raw_vstart = block_start_position.take().unwrap_or(start_position);
+                    let vstart = egui::pos2(raw_vstart.x, raw_vstart.y - content_origin_y);
+                    let vend = egui::pos2(end_position.x, end_position.y - content_origin_y);
+                    let block_src_span =
+                        block_start_src.take().unwrap_or(block_end_src)..block_end_src;
+                    scroll_cache
+                        .split_points
+                        .push((index, vstart, vend, block_src_span));
+                }
+            }
+
+            if index == 0 {
+                self.line.should_not_start_newline_forced = false;
+            }
+        }
+        content_origin_y
     }
 
     pub(crate) fn show_scrollable(
@@ -347,6 +359,7 @@ impl CommonMarkViewerInternal {
             return;
         }
 
+        // If the scroll cache is invalidated, force a full render.
         let Some(page_size) = scroll_cache(cache, &source_id).page_size else {
             egui::ScrollArea::vertical()
                 .id_salt(scroll_id)

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -341,8 +341,8 @@ impl CommonMarkViewerInternal {
                 .id_salt(scroll_id)
                 .auto_shrink([false, true])
                 .show(ui, |ui| {
-                    self.show(ui, cache, options, text, None);
                     apply_pending_scroll_delta(cache, ui);
+                    self.show(ui, cache, options, text, None);
                 });
             return;
         }
@@ -352,8 +352,8 @@ impl CommonMarkViewerInternal {
                 .id_salt(scroll_id)
                 .auto_shrink([false, true])
                 .show(ui, |ui| {
-                    self.show(ui, cache, options, text, Some(source_id));
                     apply_pending_scroll_delta(cache, ui);
+                    self.show(ui, cache, options, text, Some(source_id));
                 });
             scroll_cache(cache, &source_id).available_size = available_size;
             return;
@@ -1237,8 +1237,8 @@ mod perf_tests {
         }
     }
 
-    /// Reproduces the reported bug: clicking Next/Previous was horrendously
-    /// slow even when the target match is already on the currently visible
+    /// Reproduces the reported bug: clicking Next/Previous was pathologically
+    /// slow even when the target match was already on the currently visible
     /// page, because every call to `scroll_to_active_search_match` forced a
     /// full document re-render regardless of visibility.
     #[test]

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -138,9 +138,16 @@ fn parser_options_extras(
     result
 }
 
+/// Tracks how many full-document renders have been performed for each
+/// `show_scrollable` source, keyed by `split_points_id`. Only compiled in
+/// test builds; used by the perf-regression tests below to assert that the
+/// cheap viewport-only path is taken once split points have been populated.
+/// Because each source uses its own key, tests that run in parallel do not
+/// interfere with each other's counts.
 #[cfg(test)]
-pub(crate) static FULL_RENDER_COUNT: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+static FULL_RENDER_COUNTS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<Id, usize>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
 impl CommonMarkViewerInternal {
     /// Be aware that this acquires egui::Context internally.
@@ -154,7 +161,10 @@ impl CommonMarkViewerInternal {
         split_points_id: Option<Id>,
     ) -> (egui::InnerResponse<()>, Vec<CheckboxClickEvent>) {
         #[cfg(test)]
-        FULL_RENDER_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if let Some(sid) = split_points_id {
+            *FULL_RENDER_COUNTS.lock().unwrap().entry(sid).or_insert(0) += 1;
+        }
+
         self.any_image_loading = false;
         self.want_scroll_to_active_match = cache.take_pending_scroll_to_active_match();
         let max_width = options.max_width(ui);
@@ -1158,7 +1168,14 @@ fn apply_pending_scroll_delta(cache: &mut CommonMarkCache, ui: &mut Ui) {
 mod perf_tests {
     use super::*;
     use crate::{CommonMarkCache, CommonMarkViewer};
-    use std::sync::atomic::Ordering;
+
+    /// Returns the number of full-document renders recorded for `source_id`
+    /// since the process started (or since the entry was first created). Each
+    /// source_id has its own counter, so parallel tests do not interfere.
+    fn full_render_count_for(source_id: &str) -> usize {
+        let id = egui::Id::new(source_id);
+        *FULL_RENDER_COUNTS.lock().unwrap().get(&id).unwrap_or(&0)
+    }
 
     fn big_document() -> String {
         let mut text = String::new();
@@ -1274,7 +1291,7 @@ mod perf_tests {
         cache.set_active_search_range(Some(target));
         cache.scroll_to_active_search_match();
 
-        let before = FULL_RENDER_COUNT.load(Ordering::Relaxed);
+        let before = full_render_count_for("perf_test_offscreen_jump");
         let mut worst = std::time::Duration::ZERO;
         for _ in 0..10 {
             let frame_start = std::time::Instant::now();
@@ -1287,7 +1304,7 @@ mod perf_tests {
             output.drop_without_applying_deltas();
             worst = worst.max(frame_start.elapsed());
         }
-        let delta = FULL_RENDER_COUNT.load(Ordering::Relaxed) - before;
+        let delta = full_render_count_for("perf_test_offscreen_jump") - before;
 
         assert_eq!(
             delta, 0,
@@ -1327,10 +1344,10 @@ mod perf_tests {
         let ctx = egui::Context::default();
         ctx.set_fonts(egui::FontDefinitions::empty());
 
-        // FULL_RENDER_COUNT is a process-wide static shared with other tests
-        // in this binary, so measure the delta this test itself causes
-        // rather than an absolute count.
-        let before = FULL_RENDER_COUNT.load(Ordering::Relaxed);
+        // Each test uses its own source_id, so full_render_count_for() is
+        // keyed per source and cannot be polluted by other tests running in
+        // parallel.
+        let before = full_render_count_for("perf_test_doc");
         const FRAMES: usize = 5;
         for _ in 0..FRAMES {
             let output = ctx.run_ui(windowed_input(), |ui| {
@@ -1342,7 +1359,7 @@ mod perf_tests {
             output.drop_without_applying_deltas();
         }
 
-        let delta = FULL_RENDER_COUNT.load(Ordering::Relaxed) - before;
+        let delta = full_render_count_for("perf_test_doc") - before;
         assert!(
             delta <= 1,
             "expected at most 1 full render across {FRAMES} steady-state frames, got {delta}"

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -913,10 +913,10 @@ impl CommonMarkViewerInternal {
                 }
             }
             pulldown_cmark::TagEnd::Image => {
-                if let Some(image) = self.image.take() {
-                    if image.end(ui, options) < 1.0 {
-                        self.any_image_loading = true;
-                    }
+                if let Some(image) = self.image.take()
+                    && image.end(ui, options) < 1.0
+                {
+                    self.any_image_loading = true;
                 }
             }
             pulldown_cmark::TagEnd::HtmlBlock => {

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -180,6 +180,27 @@ impl CommonMarkViewerInternal {
         self.want_scroll_to_active_match = cache.take_pending_scroll_to_active_match();
         self.search_match_ys_scratch.clear();
         let max_width = options.max_width(ui);
+
+        // Determine the effective id for split-point recording this frame.
+        // show_scrollable's full render passes its source_id as split_points_id and
+        // always records. show_with_id stores its source_id in options and rebuilds
+        // only when the available width changes; stable frames reuse cached split points.
+        let record_id: Option<Id> = split_points_id.or_else(|| {
+            options.source_id.and_then(|id| {
+                let sc = scroll_cache(cache, &id);
+                let needs_rebuild =
+                    sc.split_points.is_empty() || (sc.available_size.x - max_width).abs() > 0.5;
+                if needs_rebuild {
+                    sc.split_points.clear();
+                    sc.heading_y_positions.clear();
+                    sc.available_size.x = max_width;
+                    Some(id)
+                } else {
+                    None // existing split points are still valid; skip re-recording
+                }
+            })
+        });
+
         let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
 
         let re = ui.allocate_ui_with_layout(egui::vec2(max_width, 0.0), layout, |ui| {
@@ -187,8 +208,7 @@ impl CommonMarkViewerInternal {
             let height = ui.text_style_height(&TextStyle::Body);
             ui.set_row_height(height);
 
-            let content_origin_y =
-                self.full_render(cache, options, text, split_points_id, max_width, ui);
+            let content_origin_y = self.full_render(cache, options, text, record_id, max_width, ui);
 
             // deferral to make it consistent no matter whether the target is before or after the link
             *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
@@ -223,7 +243,7 @@ impl CommonMarkViewerInternal {
         cache: &mut CommonMarkCache,
         options: &CommonMarkOptions<'_>,
         text: &str,
-        split_points_id: Option<Id>,
+        record_id: Option<Id>,
         max_width: f32,
         ui: &mut Ui,
     ) -> f32 {
@@ -271,7 +291,7 @@ impl CommonMarkViewerInternal {
             if let (
                 Some(sid),
                 pulldown_cmark::Event::Start(pulldown_cmark::Tag::Heading { id: Some(id), .. }),
-            ) = (split_points_id, &e)
+            ) = (record_id, &e)
             {
                 scroll_cache(cache, &sid)
                     .heading_y_positions
@@ -297,7 +317,7 @@ impl CommonMarkViewerInternal {
             let block_end_src = src_span.end;
             self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
 
-            if let Some(source_id) = split_points_id
+            if let Some(source_id) = record_id
                 && is_safe_block_end
             {
                 let scroll_cache = scroll_cache(cache, &source_id);

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -488,19 +488,29 @@ impl CommonMarkViewerInternal {
                 if let Some(y) = pending_match_scroll_y
                     && (y < viewport.min.y || y > viewport.max.y)
                 {
-                    // The match's approximate block isn't in view yet. Blind
-                    // scroll toward it; once the viewport settles there
-                    // (usually within a frame or two), the per-widget code
-                    // below will find the exact match in the now-visible
-                    // slice and refine the scroll precisely (see
-                    // `want_scroll_to_active_match` handling). If it's
-                    // already in view, skip this so we don't fight with that
-                    // precise scroll.
+                    // The match's approximate block isn't in view yet.
+                    // Scroll to its approximate position immediately (no
+                    // animation) and request a discard so this pass is never
+                    // shown to the user. In pass 2 the scroll area begins with
+                    // the offset already committed, so the viewport lands on
+                    // the target; the per-widget code below then finds the
+                    // exact match and refines the scroll precisely.
+                    //
+                    // Using ScrollAnimation::none() is essential: the
+                    // animated default takes 0.1–0.3 s, but consecutive
+                    // passes within the same run_dyn loop share nearly the
+                    // same timestamp, so the animation would not progress and
+                    // pass 2's viewport would still be at the old position.
                     let r = egui::Rect::from_min_size(
                         egui::pos2(0.0, ui.next_widget_position().y + y),
                         egui::Vec2::ZERO,
                     );
-                    ui.scroll_to_rect(r, Some(egui::Align::Center));
+                    ui.scroll_to_rect_animation(
+                        r,
+                        Some(egui::Align::Center),
+                        egui::style::ScrollAnimation::none(),
+                    );
+                    ui.ctx().request_discard("scroll to active search match");
                 }
                 if pending_delta != egui::Vec2::ZERO {
                     ui.scroll_with_delta(pending_delta);
@@ -593,27 +603,37 @@ impl CommonMarkViewerInternal {
                         // the cursor mid-row, misaligning the first visible block.
                         ui.allocate_space(egui::vec2(max_width, skip_height));
 
-                        while let Some((i, (e, src_span))) = events.next() {
-                            if events.peek().is_none() {
-                                self.line.should_end_newline_forced = false;
+                        // If this pass will be discarded (blind scroll toward an
+                        // off-screen search match), skip expensive widget rendering
+                        // entirely. The space allocation above is still needed so
+                        // that egui has the correct total height for scroll
+                        // calculations. `want_scroll_to_active_match` stays true,
+                        // so `retry_scroll_to_active_match` below re-arms the flag
+                        // for pass 2, which renders normally at the new offset.
+                        if !ui.ctx().will_discard() {
+                            while let Some((i, (e, src_span))) = events.next() {
+                                if events.peek().is_none() {
+                                    self.line.should_end_newline_forced = false;
+                                }
+                                self.process_event(
+                                    ui,
+                                    &mut events,
+                                    e,
+                                    src_span,
+                                    cache,
+                                    options,
+                                    max_width,
+                                );
+                                if i == 0 {
+                                    self.line.should_not_start_newline_forced = false;
+                                }
                             }
-                            self.process_event(
-                                ui,
-                                &mut events,
-                                e,
-                                src_span,
-                                cache,
-                                options,
-                                max_width,
-                            );
-                            if i == 0 {
-                                self.line.should_not_start_newline_forced = false;
-                            }
-                        }
 
-                        // Mirror show()'s deferred flush so that clicking a #fragment
-                        // link while in the viewport path triggers a scroll next frame.
-                        *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
+                            // Mirror show()'s deferred flush so that clicking a #fragment
+                            // link while in the viewport path triggers a scroll next frame.
+                            *cache.scroll_to_id_target_mut() =
+                                self.deferred_scroll_to_heading.take();
+                        }
                     });
                 });
             });

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -900,12 +900,14 @@ impl CommonMarkViewerInternal {
             link.push_text(self.text_style.to_richtext(ui, &text), src_span);
         } else {
             let rich_text = self.text_style.to_richtext(ui, &text);
-            let intervals = search_intervals(
-                cache.search_ranges(),
-                cache.active_search_range(),
-                &src_span,
-                text.len(),
-            );
+            let ranges = cache.search_ranges();
+            if ranges.is_empty() {
+                ui.label(rich_text);
+                return;
+            }
+
+            let intervals =
+                search_intervals(ranges, cache.active_search_range(), &src_span, text.len());
             let (_, active_rect, all_rects) = label_with_search_highlight(
                 ui,
                 rich_text,

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -871,7 +871,7 @@ impl CommonMarkViewerInternal {
         } else if let Some(block) = &mut self.code_block {
             block.push_text(&text, src_span);
         } else if let Some(link) = &mut self.link {
-            link.text.push(self.text_style.to_richtext(ui, &text));
+            link.push_text(self.text_style.to_richtext(ui, &text), src_span);
         } else {
             let rich_text = self.text_style.to_richtext(ui, &text);
             let intervals = search_intervals(
@@ -999,7 +999,7 @@ impl CommonMarkViewerInternal {
             pulldown_cmark::Tag::Link { dest_url, .. } => {
                 self.link = Some(crate::Link {
                     destination: dest_url.to_string(),
-                    text: Vec::new(),
+                    ..Default::default()
                 });
             }
             pulldown_cmark::Tag::Image { dest_url, .. } => {
@@ -1089,7 +1089,16 @@ impl CommonMarkViewerInternal {
             }
             pulldown_cmark::TagEnd::Link => {
                 if let Some(link) = self.link.take() {
-                    link.end(ui, cache, options, &mut self.deferred_scroll_to_heading);
+                    let scrolled = link.end(
+                        ui,
+                        cache,
+                        options,
+                        &mut self.deferred_scroll_to_heading,
+                        self.want_scroll_to_active_match,
+                    );
+                    if scrolled {
+                        self.want_scroll_to_active_match = false;
+                    }
                 }
             }
             pulldown_cmark::TagEnd::Image => {

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -84,6 +84,10 @@ pub struct CommonMarkViewerInternal {
     is_blockquote: bool,
     checkbox_events: Vec<CheckboxClickEvent>,
     deferred_scroll_to_heading: Option<String>,
+    /// Set during a full render if any image rendered at zero height (texture
+    /// still loading). When true, split points are discarded and the full render
+    /// repeats next frame until all images have stable heights.
+    any_image_loading: bool,
 }
 
 pub(crate) struct CheckboxClickEvent {
@@ -108,6 +112,7 @@ impl CommonMarkViewerInternal {
             is_blockquote: false,
             checkbox_events: Vec::new(),
             deferred_scroll_to_heading: None,
+            any_image_loading: false,
         }
     }
 }
@@ -137,6 +142,7 @@ impl CommonMarkViewerInternal {
         text: &str,
         split_points_id: Option<Id>,
     ) -> (egui::InnerResponse<()>, Vec<CheckboxClickEvent>) {
+        self.any_image_loading = false;
         let max_width = options.max_width(ui);
         let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
 
@@ -153,10 +159,56 @@ impl CommonMarkViewerInternal {
             .enumerate()
             .peekable();
 
+            // Screen-space y of the content origin. Subtracting this from any
+            // cursor position gives virtual (content-relative) y comparable to
+            // viewport.min/max.y from show_viewport.
+            let content_origin_y = ui.next_widget_position().y;
+
+            // Cursor at the visual top of the current block, captured at
+            // Start(Block) so that vstart reflects the block top, not its bottom.
+            let mut block_start_position: Option<Pos2> = None;
+
             while let Some((index, (e, src_span))) = events.next() {
                 let start_position = ui.next_widget_position();
-                let is_element_end = matches!(e, pulldown_cmark::Event::End(_));
-                let should_add_split_point = self.list.is_inside_a_list() && is_element_end;
+
+                let is_safe_block_start = !self.list.is_inside_a_list()
+                    && matches!(
+                        e,
+                        pulldown_cmark::Event::Start(
+                            pulldown_cmark::Tag::Paragraph
+                                | pulldown_cmark::Tag::Heading { .. }
+                                | pulldown_cmark::Tag::CodeBlock(_)
+                        )
+                    );
+                if is_safe_block_start {
+                    block_start_position = Some(start_position);
+                }
+
+                // Record virtual y for each named heading so the viewport path
+                // can jump to headings that are outside the rendered slice.
+                if let (
+                    Some(sid),
+                    pulldown_cmark::Event::Start(pulldown_cmark::Tag::Heading {
+                        id: Some(id), ..
+                    }),
+                ) = (split_points_id, &e)
+                {
+                    scroll_cache(cache, &sid)
+                        .heading_y_positions
+                        .insert(id.to_string(), ui.cursor().min.y - content_origin_y);
+                }
+
+                // Only record split points at clean, top-level block boundaries
+                // where the renderer has no pending state and can restart safely.
+                let is_safe_block_end = !self.list.is_inside_a_list()
+                    && matches!(
+                        e,
+                        pulldown_cmark::Event::End(
+                            pulldown_cmark::TagEnd::Paragraph
+                                | pulldown_cmark::TagEnd::Heading { .. }
+                                | pulldown_cmark::TagEnd::CodeBlock
+                        )
+                    );
 
                 if events.peek().is_none() {
                     self.line.should_end_newline_forced = false;
@@ -165,7 +217,7 @@ impl CommonMarkViewerInternal {
                 self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
 
                 if let Some(source_id) = split_points_id
-                    && should_add_split_point
+                    && is_safe_block_end
                 {
                     let scroll_cache = scroll_cache(cache, &source_id);
                     let end_position = ui.next_widget_position();
@@ -176,9 +228,12 @@ impl CommonMarkViewerInternal {
                         .any(|(i, _, _)| *i == index);
 
                     if !split_point_exists {
-                        scroll_cache
-                            .split_points
-                            .push((index, start_position, end_position));
+                        // Use block_start_position (Start event) not start_position
+                        // (cursor just before End) so that vstart is the block top.
+                        let raw_vstart = block_start_position.take().unwrap_or(start_position);
+                        let vstart = egui::pos2(raw_vstart.x, raw_vstart.y - content_origin_y);
+                        let vend = egui::pos2(end_position.x, end_position.y - content_origin_y);
+                        scroll_cache.split_points.push((index, vstart, vend));
                     }
                 }
 
@@ -191,8 +246,18 @@ impl CommonMarkViewerInternal {
             *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
 
             if let Some(source_id) = split_points_id {
-                scroll_cache(cache, &source_id).page_size =
-                    Some(ui.next_widget_position().to_vec2());
+                if self.any_image_loading {
+                    // Images are still loading — split points are unreliable.
+                    // Discard and leave page_size = None so the full render repeats
+                    // next frame (the image loader triggers the repaint automatically).
+                    let sc = scroll_cache(cache, &source_id);
+                    sc.split_points.clear();
+                    sc.heading_y_positions.clear();
+                } else {
+                    let final_y = ui.next_widget_position().y;
+                    scroll_cache(cache, &source_id).page_size =
+                        Some(egui::vec2(max_width, final_y - content_origin_y));
+                }
             }
         });
 
@@ -217,7 +282,6 @@ impl CommonMarkViewerInternal {
                 .show(ui, |ui| {
                     self.show(ui, cache, options, text, Some(source_id));
                 });
-            // Prevent repopulating points twice at startup
             scroll_cache(cache, &source_id).available_size = available_size;
             return;
         };
@@ -231,6 +295,23 @@ impl CommonMarkViewerInternal {
 
         let num_rows = events.len();
 
+        // Resolve any pending TOC scroll via the cached heading positions so that
+        // navigation works even when the target is outside the rendered slice.
+        let pending_scroll_y: Option<f32> = {
+            let slug_owned = cache.scroll_to_id_target().map(|s| s.to_owned());
+            if let Some(ref slug) = slug_owned {
+                let sc = scroll_cache(cache, &source_id);
+                if let Some(&y) = sc.heading_y_positions.get(slug) {
+                    cache.scroll_to_id_target_mut().take();
+                    Some(y)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+
         egui::ScrollArea::vertical()
             .id_salt(scroll_id)
             // Elements have different widths, so the scroll area cannot try to shrink to the
@@ -238,6 +319,17 @@ impl CommonMarkViewerInternal {
             // with different widths.
             .auto_shrink([false, true])
             .show_viewport(ui, |ui, viewport| {
+                if let Some(y) = pending_scroll_y {
+                    // heading_y_positions stores virtual y (content-relative, 0 = top).
+                    // Inside show_viewport, next_widget_position().y = screen_top − scroll.
+                    // scroll_to_rect with Align::TOP sets new_scroll = y. ✓
+                    let r = egui::Rect::from_min_size(
+                        egui::pos2(0.0, ui.next_widget_position().y + y),
+                        egui::Vec2::ZERO,
+                    );
+                    ui.scroll_to_rect(r, Some(egui::Align::TOP));
+                }
+
                 ui.set_height(page_size.y);
                 let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
 
@@ -246,41 +338,54 @@ impl CommonMarkViewerInternal {
                     ui.spacing_mut().item_spacing.x = 0.0;
                     let scroll_cache = scroll_cache(cache, &source_id);
 
-                    // finding the first element that's not in the viewport anymore
-                    let (first_event_index, _, first_end_position) = scroll_cache
+                    // Render one full viewport-height below the visible bottom so
+                    // that scrolling down never reveals a trailing blank region.
+                    let viewport_height = viewport.max.y - viewport.min.y;
+                    let render_below = viewport.max.y + viewport_height;
+
+                    let preceding_split = scroll_cache
                         .split_points
                         .iter()
-                        .filter(|(_, _, end_position)| end_position.y < viewport.min.y)
-                        .nth_back(1)
-                        .copied()
-                        .unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
+                        .rfind(|(_, _, vend)| vend.y < viewport.min.y)
+                        .copied();
 
-                    // finding the last element that's just outside the viewport
+                    let (_first_event_index, _, first_end_position) =
+                        preceding_split.unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
+
                     let last_event_index = scroll_cache
                         .split_points
                         .iter()
-                        .filter(|(_, start_position, _)| start_position.y > viewport.max.y)
-                        .nth(1)
+                        .find(|(_, vstart, _)| vstart.y > render_below)
                         .map(|(index, _, _)| *index)
                         .unwrap_or(num_rows);
 
-                    ui.allocate_space(first_end_position.to_vec2());
+                    // Allocate a full-width block for the off-screen content so
+                    // that the cursor lands at the correct x for the first visible block.
+                    let skip_height = first_end_position.y.max(0.0);
+                    ui.allocate_space(egui::vec2(max_width, skip_height));
 
-                    // only rendering the elements that are inside the viewport
+                    // When a preceding split was found, its End(Block) is already
+                    // accounted for in skip_height — re-processing it would add a
+                    // duplicate newline. Start from the next event instead.
+                    let (skip_count, take_count) = if let Some((idx, _, _)) = preceding_split {
+                        self.line.should_not_start_newline_forced = false;
+                        (idx + 1, last_event_index - idx)
+                    } else {
+                        (0, last_event_index)
+                    };
+
                     let mut events = events
                         .into_iter()
                         .enumerate()
-                        .skip(first_event_index)
-                        .take(last_event_index - first_event_index)
+                        .skip(skip_count)
+                        .take(take_count)
                         .peekable();
 
                     while let Some((i, (e, src_span))) = events.next() {
                         if events.peek().is_none() {
                             self.line.should_end_newline_forced = false;
                         }
-
                         self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
-
                         if i == 0 {
                             self.line.should_not_start_newline_forced = false;
                         }
@@ -288,12 +393,22 @@ impl CommonMarkViewerInternal {
                 });
             });
 
-        // Forcing full re-render to repopulate split points for the new size
+        // If any image in this render reported zero height, split points are stale.
+        // Discard them so the next frame falls back to a full render.
+        if self.any_image_loading {
+            let sc = scroll_cache(cache, &source_id);
+            sc.page_size = None;
+            sc.split_points.clear();
+            sc.heading_y_positions.clear();
+        }
+
+        // Invalidate the cache when the available size changes (e.g. window resize).
         let scroll_cache = scroll_cache(cache, &source_id);
         if available_size != scroll_cache.available_size {
             scroll_cache.available_size = available_size;
             scroll_cache.page_size = None;
             scroll_cache.split_points.clear();
+            scroll_cache.heading_y_positions.clear();
         }
     }
 
@@ -795,7 +910,9 @@ impl CommonMarkViewerInternal {
             }
             pulldown_cmark::TagEnd::Image => {
                 if let Some(image) = self.image.take() {
-                    image.end(ui, options);
+                    if image.end(ui, options) < 1.0 {
+                        self.any_image_loading = true;
+                    }
                 }
             }
             pulldown_cmark::TagEnd::HtmlBlock => {

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -232,6 +232,12 @@ impl CommonMarkViewerInternal {
                 // match after the user scrolls.
                 let viewport_top_y = ui.clip_rect().min.y - content_origin_y;
                 cache.update_show_viewport(self.search_match_ys_scratch.drain(..), viewport_top_y);
+                // For show_with_id: keep the ScrollableCache's viewport position in sync so
+                // that viewport_start_byte_offset returns the current scroll location.
+                // options.source_id is Some on every frame (including no-rebuild frames).
+                if let Some(id) = options.source_id {
+                    scroll_cache(cache, &id).last_viewport_top_y = viewport_top_y;
+                }
             }
         });
 

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -231,7 +231,12 @@ impl CommonMarkViewerInternal {
                 // and the current viewport top so callers can sync the active
                 // match after the user scrolls.
                 let viewport_top_y = ui.clip_rect().min.y - content_origin_y;
-                cache.update_show_viewport(self.search_match_ys_scratch.drain(..), viewport_top_y);
+                let viewport_height = ui.clip_rect().height();
+                cache.update_show_viewport(
+                    self.search_match_ys_scratch.drain(..),
+                    viewport_top_y,
+                    viewport_height,
+                );
                 // For show_with_id: keep the ScrollableCache's viewport position in sync so
                 // that viewport_start_byte_offset returns the current scroll location.
                 // options.source_id is Some on every frame (including no-rebuild frames).
@@ -454,16 +459,35 @@ impl CommonMarkViewerInternal {
         };
         let pending_delta = std::mem::replace(&mut cache.pending_scroll_delta, egui::Vec2::ZERO);
 
-        // Approximate virtual y of the active match, from split points
-        // collected during the last full render (see `ScrollableCache::
-        // virtual_y_for_byte_offset`). `None` only when no full render has
-        // ever populated split points yet, which resolves itself the moment
-        // one does (e.g. on first show, or after a resize/content change).
+        // Virtual y of the active match used to decide whether a blind
+        // scroll is needed before the slice renders.
+        //
+        // Prefer the precise per-match Y recorded during the *previous*
+        // frame's render (search_match_virtual_ys). That value is exact for
+        // any match that was on screen last frame — including matches deep
+        // inside tall code blocks, where virtual_y_for_byte_offset only
+        // returns the block-top Y. Using the block-top Y for such a match
+        // triggers a spurious blind scroll to the top of the block followed
+        // by a second scroll to the match, producing the "scrolls to the
+        // previous page then back" animation the user sees.
+        //
+        // Fall back to the block-level split-point approximation only when
+        // the match was not rendered last frame (Y stored as 0.0).
         let pending_match_scroll_y: Option<f32> = if self.want_scroll_to_active_match {
-            cache
-                .active_search_range()
-                .map(|r| r.start)
-                .and_then(|start| scroll_cache(cache, &source_id).virtual_y_for_byte_offset(start))
+            let precise_y = cache
+                .active_match()
+                .and_then(|i| cache.search_match_virtual_ys().get(i).copied())
+                .filter(|&y| y > 0.0);
+            if precise_y.is_some() {
+                precise_y
+            } else {
+                cache
+                    .active_search_range()
+                    .map(|r| r.start)
+                    .and_then(|start| {
+                        scroll_cache(cache, &source_id).virtual_y_for_byte_offset(start)
+                    })
+            }
         } else {
             None
         };
@@ -531,6 +555,7 @@ impl CommonMarkViewerInternal {
                     let (skip_height, skip_count, take_count) = {
                         let scroll_cache = scroll_cache(cache, &source_id);
                         scroll_cache.last_viewport_top_y = viewport.min.y;
+                        scroll_cache.last_viewport_height = viewport_height;
                         let preceding_split = scroll_cache
                             .split_points
                             .iter()
@@ -561,6 +586,15 @@ impl CommonMarkViewerInternal {
                         };
                         (skip_height, skip_count, take_count)
                     }; // scroll_cache borrow released here
+
+                    // Set content_origin_y to the screen Y of virtual-Y=0 (the
+                    // document top) for this frame. This makes match Ys recorded
+                    // by event_text comparable with viewport.min.y (the virtual
+                    // scroll offset). Matches in the rendered slice get their
+                    // exact pixel Y; those outside get the default 0.0 and are
+                    // treated as not-in-viewport by sync_scrollable_active_match.
+                    self.content_origin_y = ui.clip_rect().min.y - viewport.min.y;
+                    self.search_match_ys_scratch.clear();
 
                     let mut events = events
                         .into_iter()
@@ -633,6 +667,16 @@ impl CommonMarkViewerInternal {
                             // link while in the viewport path triggers a scroll next frame.
                             *cache.scroll_to_id_target_mut() =
                                 self.deferred_scroll_to_heading.take();
+
+                            // Flush the per-match virtual-Y positions collected by
+                            // event_text into the cache, exactly as the non-scrollable
+                            // show() path does. Skipped on discard frames (blind scroll
+                            // toward an off-screen match) because no widgets rendered.
+                            cache.update_show_viewport(
+                                self.search_match_ys_scratch.drain(..),
+                                viewport.min.y,
+                                viewport_height,
+                            );
                         }
                     });
                 });
@@ -1219,16 +1263,18 @@ impl CommonMarkViewerInternal {
             }
             pulldown_cmark::TagEnd::Link => {
                 if let Some(link) = self.link.take() {
-                    let scrolled = link.end(
+                    let (scrolled, match_ys) = link.end(
                         ui,
                         cache,
                         options,
                         &mut self.deferred_scroll_to_heading,
                         self.want_scroll_to_active_match,
+                        self.content_origin_y,
                     );
                     if scrolled {
                         self.want_scroll_to_active_match = false;
                     }
+                    self.search_match_ys_scratch.extend(match_ys);
                 }
             }
             pulldown_cmark::TagEnd::Image => {
@@ -1262,16 +1308,18 @@ impl CommonMarkViewerInternal {
         max_width: f32,
     ) {
         if let Some(block) = self.code_block.take() {
-            let scrolled = block.end(
+            let (scrolled, match_ys) = block.end(
                 ui,
                 cache,
                 options,
                 max_width,
                 self.want_scroll_to_active_match,
+                self.content_origin_y,
             );
             if scrolled {
                 self.want_scroll_to_active_match = false;
             }
+            self.search_match_ys_scratch.extend(match_ys);
             self.line.try_insert_end(ui);
         }
     }

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -9,9 +9,7 @@ use crate::List;
 use egui_commonmark_backend::elements::*;
 use egui_commonmark_backend::misc::*;
 use egui_commonmark_backend::pulldown::*;
-use egui_commonmark_backend::search::{
-    default_active_match_bg, default_match_bg, search_intervals,
-};
+use egui_commonmark_backend::search::search_intervals;
 use pulldown_cmark::{CowStr, HeadingLevel};
 
 /// Newline logic is constructed by the following:
@@ -435,6 +433,7 @@ impl CommonMarkViewerInternal {
                     let render_below = viewport.max.y + viewport_height;
                     let (skip_height, skip_count, take_count) = {
                         let scroll_cache = scroll_cache(cache, &source_id);
+                        scroll_cache.last_viewport_top_y = viewport.min.y;
                         let preceding_split = scroll_cache
                             .split_points
                             .iter()
@@ -802,22 +801,22 @@ impl CommonMarkViewerInternal {
             pulldown_cmark::Event::Start(tag) => self.start_tag(ui, tag, cache, options),
             pulldown_cmark::Event::End(tag) => self.end_tag(ui, tag, cache, options, max_width),
             pulldown_cmark::Event::Text(text) => {
-                self.event_text(text, src_span, ui, cache);
+                self.event_text(text, src_span, ui, cache, options);
             }
             pulldown_cmark::Event::Code(text) => {
                 self.text_style.code = true;
-                self.event_text(text, src_span, ui, cache);
+                self.event_text(text, src_span, ui, cache, options);
                 self.text_style.code = false;
             }
             pulldown_cmark::Event::InlineHtml(text) => {
-                self.event_text(text, src_span, ui, cache);
+                self.event_text(text, src_span, ui, cache, options);
             }
 
             pulldown_cmark::Event::Html(text) => {
                 if options.html_fn.is_some() {
                     self.html_block.push_str(&text);
                 } else {
-                    self.event_text(text, src_span, ui, cache);
+                    self.event_text(text, src_span, ui, cache, options);
                 }
             }
             pulldown_cmark::Event::FootnoteReference(footnote) => {
@@ -865,6 +864,7 @@ impl CommonMarkViewerInternal {
         src_span: Range<usize>,
         ui: &mut Ui,
         cache: &mut CommonMarkCache,
+        options: &CommonMarkOptions,
     ) {
         if let Some(image) = &mut self.image {
             image.alt_text.push(self.text_style.to_richtext(ui, &text));
@@ -884,8 +884,8 @@ impl CommonMarkViewerInternal {
                 ui,
                 rich_text,
                 &intervals,
-                default_match_bg(),
-                default_active_match_bg(),
+                options.search_match_bg(ui),
+                options.search_active_match_bg(ui),
             );
 
             if self.want_scroll_to_active_match

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -367,8 +367,12 @@ impl CommonMarkViewerInternal {
         let scroll_id = source_id.with("_scroll_area");
 
         if !options.use_viewport_cache {
-            // Simple path: render the full document every frame; egui clips
-            // what is off-screen. Clears any stale cache from a previous run.
+            // Full-document render every frame; egui clips what is off-screen.
+            // Split points are rebuilt on every frame (the full render already
+            // pays the cost) so that viewport_start_byte_offset works and
+            // update_search_matches can anchor fresh searches to the viewport.
+            // Clearing first ensures the split_point_exists check in full_render
+            // is always false, so all blocks are recorded cleanly.
             {
                 let sc = scroll_cache(cache, &source_id);
                 sc.page_size = None;
@@ -379,8 +383,19 @@ impl CommonMarkViewerInternal {
                 .id_salt(scroll_id)
                 .auto_shrink([false, true])
                 .show(ui, |ui| {
+                    // Capture viewport top before content is placed; clip_rect
+                    // already reflects the current scroll position.
+                    let viewport_top_y = ui.clip_rect().min.y - ui.next_widget_position().y;
                     apply_pending_scroll_delta(cache, ui);
-                    self.show(ui, cache, options, text, None);
+                    // Pass source_id to trigger split-point recording.
+                    self.show(ui, cache, options, text, Some(source_id));
+                    let sc = scroll_cache(cache, &source_id);
+                    // show() sets page_size as a side-effect of receiving
+                    // Some(source_id); clear it immediately so the next frame
+                    // still takes this full-render path, not the viewport-slice one.
+                    sc.page_size = None;
+                    // Keep last_viewport_top_y in sync for viewport_start_byte_offset.
+                    sc.last_viewport_top_y = viewport_top_y;
                 });
             return;
         }

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -208,6 +208,7 @@ impl CommonMarkViewerInternal {
             let height = ui.text_style_height(&TextStyle::Body);
             ui.set_row_height(height);
 
+            // Do a full render
             let content_origin_y = self.full_render(cache, options, text, record_id, max_width, ui);
 
             // deferral to make it consistent no matter whether the target is before or after the link
@@ -249,6 +250,7 @@ impl CommonMarkViewerInternal {
         (re, std::mem::take(&mut self.checkbox_events))
     }
 
+    /// Perform a full render of the document.
     fn full_render(
         &mut self,
         cache: &mut CommonMarkCache,
@@ -589,7 +591,7 @@ impl CommonMarkViewerInternal {
 
                     // Set content_origin_y to the screen Y of virtual-Y=0 (the
                     // document top) for this frame. This makes match Ys recorded
-                    // by event_text comparable with viewport.min.y (the virtual
+                    // by `event_text` comparable with viewport.min.y (the virtual
                     // scroll offset). Matches in the rendered slice get their
                     // exact pixel Y; those outside get the default 0.0 and are
                     // treated as not-in-viewport by sync_scrollable_active_match.
@@ -669,7 +671,7 @@ impl CommonMarkViewerInternal {
                                 self.deferred_scroll_to_heading.take();
 
                             // Flush the per-match virtual-Y positions collected by
-                            // event_text into the cache, exactly as the non-scrollable
+                            // `event_text` into the cache, exactly as the non-scrollable
                             // show() path does. Skipped on discard frames (blind scroll
                             // toward an off-screen match) because no widgets rendered.
                             cache.update_show_viewport(

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -336,43 +336,39 @@ impl CommonMarkViewerInternal {
                 let max_width = options.max_width(ui);
                 ui.allocate_ui_with_layout(egui::vec2(max_width, 0.0), layout, |ui| {
                     ui.spacing_mut().item_spacing.x = 0.0;
-                    let scroll_cache = scroll_cache(cache, &source_id);
 
-                    // Render one full viewport-height below the visible bottom so
-                    // that scrolling down never reveals a trailing blank region.
+                    // Compute the slice parameters and release the scroll_cache borrow
+                    // before the push_id closure so that `cache` is freely accessible
+                    // inside it.
                     let viewport_height = viewport.max.y - viewport.min.y;
                     let render_below = viewport.max.y + viewport_height;
-
-                    let preceding_split = scroll_cache
-                        .split_points
-                        .iter()
-                        .rfind(|(_, _, vend)| vend.y < viewport.min.y)
-                        .copied();
-
-                    let (_first_event_index, _, first_end_position) =
-                        preceding_split.unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
-
-                    let last_event_index = scroll_cache
-                        .split_points
-                        .iter()
-                        .find(|(_, vstart, _)| vstart.y > render_below)
-                        .map(|(index, _, _)| *index)
-                        .unwrap_or(num_rows);
-
-                    // Allocate a full-width block for the off-screen content so
-                    // that the cursor lands at the correct x for the first visible block.
-                    let skip_height = first_end_position.y.max(0.0);
-                    ui.allocate_space(egui::vec2(max_width, skip_height));
-
-                    // When a preceding split was found, its End(Block) is already
-                    // accounted for in skip_height — re-processing it would add a
-                    // duplicate newline. Start from the next event instead.
-                    let (skip_count, take_count) = if let Some((idx, _, _)) = preceding_split {
-                        self.line.should_not_start_newline_forced = false;
-                        (idx + 1, last_event_index - idx)
-                    } else {
-                        (0, last_event_index)
-                    };
+                    let (skip_height, skip_count, take_count) = {
+                        let scroll_cache = scroll_cache(cache, &source_id);
+                        let preceding_split = scroll_cache
+                            .split_points
+                            .iter()
+                            .rfind(|(_, _, vend)| vend.y < viewport.min.y)
+                            .copied();
+                        let (_first_event_index, _, first_end_position) =
+                            preceding_split.unwrap_or((0, Pos2::ZERO, Pos2::ZERO));
+                        let last_event_index = scroll_cache
+                            .split_points
+                            .iter()
+                            .find(|(_, vstart, _)| vstart.y > render_below)
+                            .map(|(index, _, _)| *index)
+                            .unwrap_or(num_rows);
+                        let skip_height = first_end_position.y.max(0.0);
+                        // When a preceding split was found, its End(Block) is already
+                        // accounted for in skip_height — re-processing it would add a
+                        // duplicate newline. Start from the next event instead.
+                        let (skip_count, take_count) = if let Some((idx, _, _)) = preceding_split {
+                            self.line.should_not_start_newline_forced = false;
+                            (idx + 1, last_event_index - idx)
+                        } else {
+                            (0, last_event_index)
+                        };
+                        (skip_height, skip_count, take_count)
+                    }; // scroll_cache borrow released here
 
                     let mut events = events
                         .into_iter()
@@ -381,19 +377,48 @@ impl CommonMarkViewerInternal {
                         .take(take_count)
                         .peekable();
 
-                    while let Some((i, (e, src_span))) = events.next() {
-                        if events.peek().is_none() {
-                            self.line.should_end_newline_forced = false;
-                        }
-                        self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
-                        if i == 0 {
-                            self.line.should_not_start_newline_forced = false;
-                        }
-                    }
+                    // Give the viewport render a distinct widget parent_id namespace
+                    // from the full-render path.  egui's warn_if_rect_changes_id check
+                    // only fires when the same screen rect has different widget IDs
+                    // *and* at least one widget shares a parent_id between consecutive
+                    // frames.  Using a different salt here vs the full-render path makes
+                    // the parent_id comparison always fail on the transition frame,
+                    // eliminating the spurious one-frame red outlines on image load and
+                    // window resize.
+                    //
+                    // IMPORTANT: push_id must be called BEFORE allocate_space so that
+                    // the cursor is still at (0, 0) — the left edge of a full-width row.
+                    // Calling it after allocate_space leaves the cursor at (max_width, …)
+                    // (right edge), making available_rect_before_wrap() return a
+                    // near-zero width and collapsing all content to a 1-pixel stripe.
+                    ui.push_id("__cm_viewport", |ui| {
+                        // Skip over off-screen content by reserving its vertical space.
+                        // Full width is essential: a narrower allocation would leave
+                        // the cursor mid-row, misaligning the first visible block.
+                        ui.allocate_space(egui::vec2(max_width, skip_height));
 
-                    // Mirror show()'s deferred flush so that clicking a #fragment link
-                    // while in the viewport path also triggers a scroll next frame.
-                    *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
+                        while let Some((i, (e, src_span))) = events.next() {
+                            if events.peek().is_none() {
+                                self.line.should_end_newline_forced = false;
+                            }
+                            self.process_event(
+                                ui,
+                                &mut events,
+                                e,
+                                src_span,
+                                cache,
+                                options,
+                                max_width,
+                            );
+                            if i == 0 {
+                                self.line.should_not_start_newline_forced = false;
+                            }
+                        }
+
+                        // Mirror show()'s deferred flush so that clicking a #fragment
+                        // link while in the viewport path triggers a scroll next frame.
+                        *cache.scroll_to_id_target_mut() = self.deferred_scroll_to_heading.take();
+                    });
                 });
             });
 

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -382,20 +382,34 @@ impl CommonMarkViewerInternal {
                         .peekable();
 
                     // Give the viewport render a distinct widget parent_id namespace
-                    // from the full-render path.  egui's warn_if_rect_changes_id check
-                    // only fires when the same screen rect has different widget IDs
-                    // *and* at least one widget shares a parent_id between consecutive
-                    // frames.  Using a different salt here vs the full-render path makes
-                    // the parent_id comparison always fail on the transition frame,
-                    // eliminating the spurious one-frame red outlines on image load and
-                    // window resize.
+                    // so that egui's warn_if_rect_changes_id check never fires.
+                    //
+                    // The check fires when the same screen rect has different widget
+                    // IDs *and* at least one widget shares a parent_id between
+                    // consecutive frames.  Widget IDs within this push_id scope are
+                    // counter-based (sequential from 0 each frame).  The counter
+                    // resets at the start of each rendered slice, so when skip_count
+                    // advances by 1 (viewport crosses a split-point boundary), every
+                    // widget in the visible overlap shifts its ID by 1 — same rect,
+                    // same parent_id, different ID → warning fires.
+                    //
+                    // Fix: bake skip_count into the push_id salt.  Consecutive frames
+                    // with different skip_count values get different parent_ids, so the
+                    // parent_id match condition is never met.  When skip_count is
+                    // stable (viewport moves within a split-point interval), the same
+                    // slice renders with identical counter values → same IDs → no
+                    // warning then either.
+                    //
+                    // The salt tuple also differs from the full-render path's implicit
+                    // parent (no push_id), so the transition-frame guard from the
+                    // full→viewport fix remains intact.
                     //
                     // IMPORTANT: push_id must be called BEFORE allocate_space so that
-                    // the cursor is still at (0, 0) — the left edge of a full-width row.
-                    // Calling it after allocate_space leaves the cursor at (max_width, …)
-                    // (right edge), making available_rect_before_wrap() return a
-                    // near-zero width and collapsing all content to a 1-pixel stripe.
-                    ui.push_id("__cm_viewport", |ui| {
+                    // the cursor is still at (0, 0) — the left edge of a full-width
+                    // row.  Calling it after allocate_space leaves the cursor at
+                    // (max_width, …) (right edge), making available_rect_before_wrap()
+                    // return near-zero width and collapsing all content to a thin strip.
+                    ui.push_id(("__cm_viewport", skip_count), |ui| {
                         // Skip over off-screen content by reserving its vertical space.
                         // Full width is essential: a narrower allocation would leave
                         // the cursor mid-row, misaligning the first visible block.

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -363,7 +363,11 @@ impl CommonMarkViewerInternal {
                         // duplicate newline. Start from the next event instead.
                         let (skip_count, take_count) = if let Some((idx, _, _)) = preceding_split {
                             self.line.should_not_start_newline_forced = false;
-                            (idx + 1, last_event_index - idx)
+                            // last_event_index should always be >= idx because
+                            // split-points are ordered, but guard against stale
+                            // cache or tiny documents producing an underflow.
+                            let take = last_event_index.saturating_sub(idx);
+                            (idx + 1, take)
                         } else {
                             (0, last_event_index)
                         };

--- a/egui_commonmark/src/parsers/pulldown.rs
+++ b/egui_commonmark/src/parsers/pulldown.rs
@@ -710,10 +710,15 @@ impl CommonMarkViewerInternal {
             }
         }
 
-        // Invalidate the cache when the available size changes (e.g. window resize).
+        // Invalidate the cache when the available *width* changes (e.g. window resize).
+        // Height changes — such as the search bar or TOC panel opening/closing —
+        // do not affect split points or page_size: text wrapping only depends on
+        // width, so a height-only change must never force a full render, especially on
+        // a large document.
         let scroll_cache = scroll_cache(cache, &source_id);
-        if available_size != scroll_cache.available_size {
-            scroll_cache.available_size = available_size;
+        let width_changed = (available_size.x - scroll_cache.available_size.x).abs() > 0.5;
+        scroll_cache.available_size = available_size; // always keep Y bookkeeping current
+        if width_changed {
             scroll_cache.page_size = None;
             scroll_cache.split_points.clear();
             scroll_cache.heading_y_positions.clear();

--- a/egui_commonmark_backend/Cargo.toml
+++ b/egui_commonmark_backend/Cargo.toml
@@ -25,6 +25,9 @@ syntect = { version = "5.0.0", optional = true, default-features = false, featur
     "default-fancy",
 ] }
 
+regex = "1"
+bitflags = "2"
+
 [features]
 better_syntax_highlighting = ["dep:syntect"]
 embedded_image = ["dep:data-url"]

--- a/egui_commonmark_backend/src/elements.rs
+++ b/egui_commonmark_backend/src/elements.rs
@@ -121,12 +121,16 @@ pub fn label_with_search_highlight(
         egui::WidgetInfo::labeled(egui::WidgetType::Label, ui.is_enabled(), galley.text())
     });
 
-    let mut active_rect = None;
-    if ui.is_rect_visible(response.rect) {
-        if let Some((range, true)) = intervals.iter().find(|(_, active)| *active) {
-            active_rect = highlight_rect_for_byte_range(&galley, pos, range.clone());
-        }
+    // Compute the active-match rect unconditionally: `pos` and `galley` hold
+    // valid screen-coordinate data even when the label is outside the clip
+    // rect, and callers need this rect to scroll to a match that is currently
+    // off-screen. Only the *painting* step below stays inside `is_rect_visible`.
+    let active_rect = intervals
+        .iter()
+        .find(|(_, active)| *active)
+        .and_then(|(range, _)| highlight_rect_for_byte_range(&galley, pos, range.clone()));
 
+    if ui.is_rect_visible(response.rect) {
         let response_color = ui.style().visuals.text_color();
         let selectable = ui.style().interaction.selectable_labels;
         if selectable {

--- a/egui_commonmark_backend/src/elements.rs
+++ b/egui_commonmark_backend/src/elements.rs
@@ -162,8 +162,8 @@ pub fn label_with_search_highlight(
 
 /// The rect (in screen coordinates) spanned by the given byte range within
 /// `galley`'s text, or `None` if the range is empty. Used to scroll the
-/// active search match into view.
-fn highlight_rect_for_byte_range(
+/// active search match into view and to record per-match virtual-Y positions.
+pub fn highlight_rect_for_byte_range(
     galley: &std::sync::Arc<egui::Galley>,
     pos: Pos2,
     local_byte_range: Range<usize>,
@@ -188,13 +188,16 @@ fn highlight_rect_for_byte_range(
 }
 
 /// Enhanced/specialized version of egui's code blocks. This one features copy button and borders
+/// Returns `(galley_pos, galley)` so the caller can compute per-match
+/// virtual-Y positions via [`highlight_rect_for_byte_range`] without a
+/// second layout pass.
 pub fn code_block<'t>(
     ui: &mut Ui,
     max_width: f32,
     text: &str,
     layouter: &'t mut dyn FnMut(&Ui, &dyn TextBuffer, f32) -> std::sync::Arc<egui::Galley>,
     scroll_to_active_match: Option<Range<usize>>,
-) {
+) -> (egui::Pos2, std::sync::Arc<egui::Galley>) {
     let mut text = text.strip_suffix('\n').unwrap_or(text);
 
     // To manually add background color to the code block, we imitate what
@@ -284,6 +287,8 @@ pub fn code_block<'t>(
         };
         ui.copy_text(copy_text);
     }
+
+    (output.galley_pos, output.galley)
 }
 
 // Stripped down version of egui's Checkbox. The only difference is that this

--- a/egui_commonmark_backend/src/elements.rs
+++ b/egui_commonmark_backend/src/elements.rs
@@ -95,16 +95,19 @@ fn width_body_space(ui: &Ui) -> f32 {
 /// `intervals` are supplied, so that toggling or changing search matches
 /// never shifts egui's auto-generated widget IDs for subsequent widgets.
 ///
-/// Returns the widget's response, plus the on-screen rect of the active
-/// match (if `intervals` contains one and it is visible), which callers can
-/// use to scroll it into view.
+/// Returns the widget's response, the on-screen rect of the active match
+/// (if `intervals` contains one), and a `Vec` with one `Option<Rect>` per
+/// interval (in the same order as `intervals`): `Some(rect)` for each
+/// match whose byte range is non-empty, `None` otherwise. All rects are
+/// computed unconditionally even when the label is outside the clip rect,
+/// so callers can use them to track match positions during scrolling.
 pub fn label_with_search_highlight(
     ui: &mut Ui,
     text: RichText,
     intervals: &[(Range<usize>, bool)],
     match_bg: Color32,
     active_bg: Color32,
-) -> (egui::Response, Option<Rect>) {
+) -> (egui::Response, Option<Rect>, Vec<Option<Rect>>) {
     let widget_text: WidgetText = if intervals.is_empty() {
         text.into()
     } else {
@@ -121,14 +124,20 @@ pub fn label_with_search_highlight(
         egui::WidgetInfo::labeled(egui::WidgetType::Label, ui.is_enabled(), galley.text())
     });
 
-    // Compute the active-match rect unconditionally: `pos` and `galley` hold
+    // Compute rects for all intervals unconditionally: `pos` and `galley` hold
     // valid screen-coordinate data even when the label is outside the clip
-    // rect, and callers need this rect to scroll to a match that is currently
-    // off-screen. Only the *painting* step below stays inside `is_rect_visible`.
+    // rect. The active-match rect is used to scroll it into view; the full
+    // set is returned so callers can track every match's position during
+    // scrolling. Only the *painting* step below stays inside `is_rect_visible`.
+    let all_rects: Vec<Option<Rect>> = intervals
+        .iter()
+        .map(|(range, _)| highlight_rect_for_byte_range(&galley, pos, range.clone()))
+        .collect();
     let active_rect = intervals
         .iter()
-        .find(|(_, active)| *active)
-        .and_then(|(range, _)| highlight_rect_for_byte_range(&galley, pos, range.clone()));
+        .enumerate()
+        .find(|(_, (_, active))| *active)
+        .and_then(|(i, _)| all_rects[i]);
 
     if ui.is_rect_visible(response.rect) {
         let response_color = ui.style().visuals.text_color();
@@ -148,7 +157,7 @@ pub fn label_with_search_highlight(
         }
     }
 
-    (response, active_rect)
+    (response, active_rect, all_rects)
 }
 
 /// The rect (in screen coordinates) spanned by the given byte range within

--- a/egui_commonmark_backend/src/elements.rs
+++ b/egui_commonmark_backend/src/elements.rs
@@ -1,4 +1,6 @@
 use egui::{self, NumExt, RichText, Sense, TextBuffer, TextStyle, Ui, Vec2, epaint};
+use egui::{Color32, Pos2, Rect, WidgetText, text::CCursor};
+use std::ops::Range;
 
 #[inline]
 pub fn rule(ui: &mut Ui, end_line: bool) {
@@ -86,12 +88,99 @@ fn width_body_space(ui: &Ui) -> f32 {
     ui.fonts_mut(|f| f.glyph_width(&id, ' '))
 }
 
+/// Render a run of text as a single label, optionally painting search-match
+/// backgrounds behind some of its characters.
+///
+/// This always creates exactly one widget, regardless of how many (if any)
+/// `intervals` are supplied, so that toggling or changing search matches
+/// never shifts egui's auto-generated widget IDs for subsequent widgets.
+///
+/// Returns the widget's response, plus the on-screen rect of the active
+/// match (if `intervals` contains one and it is visible), which callers can
+/// use to scroll it into view.
+pub fn label_with_search_highlight(
+    ui: &mut Ui,
+    text: RichText,
+    intervals: &[(Range<usize>, bool)],
+    match_bg: Color32,
+    active_bg: Color32,
+) -> (egui::Response, Option<Rect>) {
+    let widget_text: WidgetText = if intervals.is_empty() {
+        text.into()
+    } else {
+        let valign = ui.text_valign();
+        let job_arc: std::sync::Arc<egui::text::LayoutJob> = WidgetText::from(text)
+            .into_layout_job(ui.style(), egui::FontSelection::Default, valign);
+        let mut job = std::sync::Arc::unwrap_or_clone(job_arc);
+        crate::search::apply_search_highlights(&mut job, intervals, match_bg, active_bg);
+        job.into()
+    };
+
+    let (pos, galley, response) = egui::Label::new(widget_text).layout_in_ui(ui);
+    response.widget_info(|| {
+        egui::WidgetInfo::labeled(egui::WidgetType::Label, ui.is_enabled(), galley.text())
+    });
+
+    let mut active_rect = None;
+    if ui.is_rect_visible(response.rect) {
+        if let Some((range, true)) = intervals.iter().find(|(_, active)| *active) {
+            active_rect = highlight_rect_for_byte_range(&galley, pos, range.clone());
+        }
+
+        let response_color = ui.style().visuals.text_color();
+        let selectable = ui.style().interaction.selectable_labels;
+        if selectable {
+            egui::text_selection::LabelSelectionState::label_text_selection(
+                ui,
+                &response,
+                pos,
+                galley,
+                response_color,
+                egui::Stroke::NONE,
+            );
+        } else {
+            ui.painter()
+                .add(epaint::TextShape::new(pos, galley, response_color));
+        }
+    }
+
+    (response, active_rect)
+}
+
+/// The rect (in screen coordinates) spanned by the given byte range within
+/// `galley`'s text, or `None` if the range is empty. Used to scroll the
+/// active search match into view.
+fn highlight_rect_for_byte_range(
+    galley: &std::sync::Arc<egui::Galley>,
+    pos: Pos2,
+    local_byte_range: Range<usize>,
+) -> Option<Rect> {
+    let text = &galley.job.text;
+    if local_byte_range.start >= local_byte_range.end {
+        return None;
+    }
+
+    let char_count_up_to = |byte_idx: usize| -> usize {
+        text.get(..byte_idx.min(text.len()))
+            .map_or_else(|| text.chars().count(), |s| s.chars().count())
+    };
+
+    let start_char = char_count_up_to(local_byte_range.start);
+    let end_char = char_count_up_to(local_byte_range.end);
+
+    let start_rect = galley.pos_from_cursor(CCursor::new(start_char));
+    let end_rect = galley.pos_from_cursor(CCursor::new(end_char));
+
+    Some(Rect::from_two_pos(start_rect.min, end_rect.max).translate(pos.to_vec2()))
+}
+
 /// Enhanced/specialized version of egui's code blocks. This one features copy button and borders
 pub fn code_block<'t>(
     ui: &mut Ui,
     max_width: f32,
     text: &str,
     layouter: &'t mut dyn FnMut(&Ui, &dyn TextBuffer, f32) -> std::sync::Arc<egui::Galley>,
+    scroll_to_active_match: Option<Range<usize>>,
 ) {
     let mut text = text.strip_suffix('\n').unwrap_or(text);
 
@@ -108,6 +197,12 @@ pub fn code_block<'t>(
         // prevent trailing lines
         .desired_rows(1)
         .show(ui);
+
+    if let Some(range) = scroll_to_active_match
+        && let Some(rect) = highlight_rect_for_byte_range(&output.galley, output.galley_pos, range)
+    {
+        ui.scroll_to_rect(rect, Some(egui::Align::Center));
+    }
 
     // Background color + frame (This is lost when TextEdit it not editable)
     let frame_rect = output.response.rect;

--- a/egui_commonmark_backend/src/lib.rs
+++ b/egui_commonmark_backend/src/lib.rs
@@ -25,8 +25,8 @@ pub use {
     misc::{CodeBlock, CommonMarkOptions, Image, Link, prepare_show},
 };
 
-// The only struct that is allowed to use directly. (If one does not need egui_commonmark)
-pub use misc::CommonMarkCache;
+// The only structs that may be used directly. (If one does not need egui_commonmark)
+pub use misc::{CommonMarkCache, SearchOptions};
 
 #[cfg(feature = "better_syntax_highlighting")]
 pub use syntect;

--- a/egui_commonmark_backend/src/lib.rs
+++ b/egui_commonmark_backend/src/lib.rs
@@ -10,6 +10,8 @@ pub mod elements;
 pub mod misc;
 #[doc(hidden)]
 pub mod pulldown;
+#[doc(hidden)]
+pub mod search;
 
 #[cfg(feature = "embedded_image")]
 mod data_url_loader;

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -263,20 +263,35 @@ impl Image {
         }
     }
 
-    pub fn end(self, ui: &mut Ui, options: &CommonMarkOptions) {
+    /// Returns the rendered height in points, or `0.0` if the texture is still
+    /// loading. The caller uses this to detect whether split-point heights can
+    /// be trusted.
+    pub fn end(self, ui: &mut Ui, options: &CommonMarkOptions) -> f32 {
+        let Self { uri, alt_text } = self;
         let response = ui.add(
-            egui::Image::from_uri(&self.uri)
+            egui::Image::from_uri(&uri)
                 .fit_to_original_size(1.0)
                 .max_width(options.max_width(ui)),
         );
-
-        if !self.alt_text.is_empty() && options.show_alt_text_on_hover {
+        let height = response.rect.height();
+        if !alt_text.is_empty() && options.show_alt_text_on_hover {
             response.on_hover_ui_at_pointer(|ui| {
-                for alt in self.alt_text {
+                for alt in alt_text {
                     ui.label(alt);
                 }
             });
         }
+        // egui's 24×24 placeholder means height ≥ 1.0 even while Pending, so
+        // query the load state directly rather than relying on height alone.
+        let is_pending = matches!(
+            ui.ctx().try_load_texture(
+                &uri,
+                egui::TextureOptions::default(),
+                egui::load::SizeHint::default(),
+            ),
+            Ok(egui::load::TexturePoll::Pending { .. })
+        );
+        if is_pending { 0.0 } else { height }
     }
 }
 

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -1,4 +1,5 @@
 use crate::alerts::AlertBundle;
+use bitflags::bitflags;
 use egui::{RichText, TextBuffer, TextStyle, Ui, text::LayoutJob};
 use std::collections::HashMap;
 use std::ops::Range;
@@ -585,6 +586,15 @@ fn default_theme(ui: &Ui) -> &str {
     }
 }
 
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    pub struct SearchOptions: u8 {
+        const CASE_SENSITIVE = 1 << 0;
+        const WHOLE_WORD     = 1 << 1;
+        const REGEX          = 1 << 2;
+    }
+}
+
 /// A cache used for storing content such as images.
 #[derive(Debug)]
 pub struct CommonMarkCache {
@@ -608,6 +618,10 @@ pub struct CommonMarkCache {
 
     /// The search query text
     pub search_query: String,
+    /// The search options
+    pub search_options: SearchOptions,
+    /// Any regex message, e.g. when an escape character is being typed
+    pub search_regex_error: Option<String>,
     /// Byte ranges (into the source text passed to the viewer) that should
     /// be highlighted as search matches.
     search_ranges: Vec<Range<usize>>,
@@ -653,6 +667,8 @@ impl Default for CommonMarkCache {
             has_installed_loaders: false,
             pending_scroll_delta: egui::Vec2::ZERO,
             search_query: String::new(),
+            search_options: SearchOptions::empty(),
+            search_regex_error: None,
             search_ranges: Vec::new(),
             active_search_range: None,
             active_match: None,
@@ -926,31 +942,62 @@ impl CommonMarkCache {
             .unwrap_or(0);
 
         self.search_ranges.clear();
-        if !self.search_query.is_empty() {
-            let query = self.search_query.to_lowercase();
-            // Mirror the options CommonMarkViewer itself parses with,
-            // including heading attributes since `enable_scroll_to_heading`
-            // is set below (otherwise `{#section-500}` would remain in the
-            // heading's Text event and get matched too).
-            let options = pulldown_cmark::Options::ENABLE_STRIKETHROUGH
-                | pulldown_cmark::Options::ENABLE_TASKLISTS
-                | pulldown_cmark::Options::ENABLE_TABLES
-                | pulldown_cmark::Options::ENABLE_FOOTNOTES
-                | pulldown_cmark::Options::ENABLE_HEADING_ATTRIBUTES;
-            let parser = pulldown_cmark::Parser::new_ext(content, options).into_offset_iter();
-            for (event, range) in parser {
-                let (pulldown_cmark::Event::Text(text) | pulldown_cmark::Event::Code(text)) = event
-                else {
-                    continue;
-                };
-                let haystack = text.to_lowercase();
-                let mut start = 0;
-                while let Some(pos) = haystack[start..].find(&query) {
-                    let match_start = range.start + start + pos;
-                    let match_end = match_start + query.len();
-                    self.search_ranges.push(match_start..match_end);
-                    start += pos + query.len();
-                }
+
+        let query = &self.search_query;
+
+        if query.is_empty() {
+            return;
+        }
+
+        let options = self.search_options;
+
+        let mut pattern = if options.contains(SearchOptions::REGEX) {
+            query.clone()
+        } else {
+            regex::escape(&query)
+        };
+
+        if options.contains(SearchOptions::WHOLE_WORD) {
+            pattern = format!(r"\b(?:{pattern})\b");
+        }
+
+        let regex = match regex::RegexBuilder::new(&pattern)
+            .case_insensitive(!options.contains(SearchOptions::CASE_SENSITIVE))
+            .build()
+        {
+            Ok(regex) => {
+                self.search_regex_error = None;
+                regex
+            }
+            Err(err) => {
+                self.search_regex_error = Some(err.to_string());
+                return;
+            }
+        };
+
+        // Mirror the options CommonMarkViewer itself parses with,
+        // including heading attributes since `enable_scroll_to_heading`
+        // is set below (otherwise `{#section-500}` would remain in the
+        // heading's Text event and get matched too).
+        let options = pulldown_cmark::Options::ENABLE_STRIKETHROUGH
+            | pulldown_cmark::Options::ENABLE_TASKLISTS
+            | pulldown_cmark::Options::ENABLE_TABLES
+            | pulldown_cmark::Options::ENABLE_FOOTNOTES
+            | pulldown_cmark::Options::ENABLE_HEADING_ATTRIBUTES;
+
+        let parser = pulldown_cmark::Parser::new_ext(content, options).into_offset_iter();
+
+        for (event, range) in parser {
+            let (pulldown_cmark::Event::Text(text) | pulldown_cmark::Event::Code(text)) = event
+            else {
+                continue;
+            };
+
+            for matched in regex.find_iter(&text) {
+                let match_start = range.start + matched.start();
+                let match_end = range.start + matched.end();
+
+                self.search_ranges.push(match_start..match_end);
             }
         }
 

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -375,6 +375,12 @@ impl Link {
 pub struct Image {
     pub uri: String,
     pub alt_text: Vec<RichText>,
+    /// Source byte spans (in the original markdown) of each alt-text [`Text`]
+    /// event accumulated while this image was being parsed. Used to match
+    /// global search ranges against the image at render time.
+    ///
+    /// [`Text`]: pulldown_cmark::Event::Text
+    pub alt_src_spans: Vec<Range<usize>>,
 }
 
 impl Image {
@@ -391,20 +397,51 @@ impl Image {
         Self {
             uri,
             alt_text: Vec::new(),
+            alt_src_spans: Vec::new(),
         }
     }
 
-    /// Returns the rendered height in points, or `0.0` if the texture is still
-    /// loading. The caller uses this to detect whether split-point heights can
-    /// be trusted.
-    pub fn end(self, ui: &mut Ui, options: &CommonMarkOptions) -> f32 {
-        let Self { uri, alt_text } = self;
+    /// Append a piece of alt text, recording its source span so that search
+    /// matches can later be mapped back onto it (mirroring [`Link::push_text`]).
+    pub fn push_alt_text(&mut self, text: RichText, src_span: Range<usize>) {
+        self.alt_text.push(text);
+        self.alt_src_spans.push(src_span);
+    }
+
+    /// Renders the image.
+    ///
+    /// Returns `(height, scrolled, match_ys)` where:
+    /// - `height` is `0.0` while the texture is still loading (same semantics
+    ///   as before; the caller uses it to detect unreliable split-point heights),
+    /// - `scrolled` is `true` if the active search match fell on this image and
+    ///   the view was scrolled to it (the caller should then clear
+    ///   `want_scroll_to_active_match`),
+    /// - `match_ys` is a list of `(global_match_index, virtual_y)` pairs for
+    ///   every global search range that overlaps any of the image's alt-text
+    ///   source spans. The caller should extend `search_match_ys_scratch` with
+    ///   these so that `sync_active_match` can locate the image on screen.
+    pub fn end(
+        self,
+        ui: &mut Ui,
+        cache: &CommonMarkCache,
+        options: &CommonMarkOptions,
+        want_scroll_to_active_match: bool,
+        content_origin_y: f32,
+    ) -> (f32, bool, Vec<(usize, f32)>) {
+        let Self {
+            uri,
+            alt_text,
+            alt_src_spans,
+        } = self;
+
         let response = ui.add(
             egui::Image::from_uri(&uri)
                 .fit_to_original_size(1.0)
                 .max_width(options.max_width(ui)),
         );
-        let height = response.rect.height();
+        // Save the rect now; `on_hover_ui_at_pointer` consumes `response`.
+        let rect = response.rect;
+
         if !alt_text.is_empty() && options.show_alt_text_on_hover {
             response.on_hover_ui_at_pointer(|ui| {
                 for alt in alt_text {
@@ -412,6 +449,7 @@ impl Image {
                 }
             });
         }
+
         // egui's 24×24 placeholder means height ≥ 1.0 even while Pending, so
         // query the load state directly rather than relying on height alone.
         let is_pending = matches!(
@@ -422,7 +460,61 @@ impl Image {
             ),
             Ok(egui::load::TexturePoll::Pending { .. })
         );
-        if is_pending { 0.0 } else { height }
+        let height = if is_pending { 0.0 } else { rect.height() };
+
+        // --- Search match handling ---
+        let ranges = cache.search_ranges();
+        if ranges.is_empty() || alt_src_spans.is_empty() {
+            return (height, false, vec![]);
+        }
+
+        let has_active_match = cache.active_search_range().is_some_and(|a| {
+            alt_src_spans
+                .iter()
+                .any(|span| a.start < span.end && a.end > span.start)
+        });
+
+        // One `(global_index, virtual_y)` entry per matching search range.
+        let virtual_y = rect.min.y - content_origin_y;
+        let match_ys: Vec<(usize, f32)> = ranges
+            .iter()
+            .enumerate()
+            .filter(|(_, r)| {
+                r.start < r.end
+                    && alt_src_spans
+                        .iter()
+                        .any(|span| r.start < span.end && r.end > span.start)
+            })
+            .map(|(i, _)| (i, virtual_y))
+            .collect();
+
+        // Draw a colored border around the image for every match that hits it.
+        // Active match gets a thicker, more prominent stroke.
+        if !match_ys.is_empty() && ui.is_rect_visible(rect) {
+            let make_opaque = |c: egui::Color32| egui::Color32::from_rgb(c.r(), c.g(), c.b());
+            let (stroke_color, stroke_width): (egui::Color32, f32) = if has_active_match {
+                (make_opaque(options.search_active_match_bg(ui)), 2.0)
+            } else {
+                (make_opaque(options.search_match_bg(ui)), 1.5)
+            };
+            ui.painter().add(egui::epaint::RectShape::new(
+                rect,
+                egui::CornerRadius::default(),
+                egui::Color32::TRANSPARENT,
+                egui::Stroke::new(stroke_width, stroke_color),
+                egui::StrokeKind::Outside,
+            ));
+        }
+
+        // Scroll the active match into view if requested.
+        let scrolled = if has_active_match && want_scroll_to_active_match {
+            ui.scroll_to_rect(rect, Some(egui::Align::Center));
+            true
+        } else {
+            false
+        };
+
+        (height, scrolled, match_ys)
     }
 }
 

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -568,6 +568,16 @@ fn default_theme(ui: &Ui) -> &str {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ScrollAction {
+    LineUp,
+    LineDown,
+    PageUp,
+    PageDown,
+    DocTop,
+    DocBottom,
+}
+
 /// A cache used for storing content such as images.
 #[derive(Debug)]
 pub struct CommonMarkCache {
@@ -919,7 +929,6 @@ impl CommonMarkCache {
         }
 
         let cursor = self.viewport_start_byte_offset(egui_source_id).unwrap_or(0);
-        dbg!(cursor);
         let nearest = self
             .search_ranges
             .iter()
@@ -1087,6 +1096,59 @@ impl CommonMarkCache {
             .get(options.curr_theme(ui))
             // Since we have called load_defaults, the default theme *should* always be available..
             .unwrap_or_else(|| &self.ts.themes[default_theme(ui)])
+    }
+
+    /// Handles keyboard scrolling input and updates cache delta.
+    /// Returns `true` if any explicit user scrolling (wheel or keyboard) occurred.
+    pub fn handle_keyboard_scrolling(&mut self, ui: &egui::Ui) -> bool {
+        let scroll_action = ui.ctx().input(|i| {
+            use egui::Key;
+            if i.key_pressed(Key::Home) || (i.modifiers.command && i.key_pressed(Key::ArrowUp)) {
+                Some(ScrollAction::DocTop)
+            } else if i.key_pressed(Key::End)
+                || (i.modifiers.command && i.key_pressed(Key::ArrowDown))
+            {
+                Some(ScrollAction::DocBottom)
+            } else if i.key_pressed(Key::PageUp) {
+                Some(ScrollAction::PageUp)
+            } else if i.key_pressed(Key::PageDown) {
+                Some(ScrollAction::PageDown)
+            } else if !i.modifiers.command && i.key_pressed(Key::ArrowUp) {
+                Some(ScrollAction::LineUp)
+            } else if !i.modifiers.command && i.key_pressed(Key::ArrowDown) {
+                Some(ScrollAction::LineDown)
+            } else {
+                None
+            }
+        });
+
+        let no_text_focus = !ui.ctx().egui_wants_keyboard_input();
+        let key_scrolled = no_text_focus && scroll_action.is_some();
+
+        if key_scrolled {
+            if let Some(action) = scroll_action {
+                let line_h = ui.text_style_height(&egui::TextStyle::Body);
+                let page_h = ui.available_height();
+
+                let delta_y = match action {
+                    ScrollAction::LineUp => line_h,
+                    ScrollAction::LineDown => -line_h,
+                    ScrollAction::PageUp => page_h,
+                    ScrollAction::PageDown => -page_h,
+                    ScrollAction::DocTop => f32::MAX / 2.0,
+                    ScrollAction::DocBottom => -f32::MAX / 2.0,
+                };
+
+                self.set_scroll_delta(egui::vec2(0.0, delta_y));
+            }
+        }
+
+        let user_scroll_input = ui.input(|i| i.is_scrolling()) || key_scrolled;
+        if user_scroll_input {
+            self.search_scroll_protection = 0;
+        }
+
+        user_scroll_input
     }
 }
 

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -589,12 +589,16 @@ pub struct CommonMarkCache {
     /// `show_scrollable` call and then cleared.
     pub pending_scroll_delta: egui::Vec2,
 
+    /// The search query text
+    pub search_query: String,
     /// Byte ranges (into the source text passed to the viewer) that should
     /// be highlighted as search matches.
     search_ranges: Vec<Range<usize>>,
     /// The currently active (focused) search match, highlighted more
     /// prominently than the others.
     active_search_range: Option<Range<usize>>,
+    /// The ordinal number of the active search match
+    active_match: Option<usize>,
     /// Set by [`CommonMarkCache::scroll_to_active_search_match`] and cleared
     /// once the render pass that finds and scrolls to the active match runs.
     pending_scroll_to_active_match: bool,
@@ -618,8 +622,10 @@ impl Default for CommonMarkCache {
             scroll_to_id_target: None,
             has_installed_loaders: false,
             pending_scroll_delta: egui::Vec2::ZERO,
+            search_query: String::new(),
             search_ranges: Vec::new(),
             active_search_range: None,
+            active_match: None,
             pending_scroll_to_active_match: false,
             pending_scroll_to_active_match_retries: 0,
         }
@@ -743,6 +749,11 @@ impl CommonMarkCache {
         self.active_search_range.as_ref()
     }
 
+    /// The ordinal number of the currently active (focused) search match, if any.
+    pub fn active_match(&self) -> Option<usize> {
+        self.active_match
+    }
+
     /// Request that the view scroll so that the active search match (set via
     /// [`set_active_search_range`](Self::set_active_search_range)) becomes
     /// visible, centered in the viewport where possible. The request is
@@ -782,7 +793,96 @@ impl CommonMarkCache {
         true
     }
 
-    /// Clear the cache for all scrollable elements
+    /// Recomputes `search_ranges` from the *rendered* text only (via
+    /// pulldown-cmark's `Text`/`Code` events), so link destinations,
+    /// heading `{#id}` attribute syntax, and other non-visible markdown
+    /// syntax are never matched (a naive substring search over the raw
+    /// source would, for example, double-count "500" in
+    /// `[Section 500](#section-500)`: once in the visible text, once in the
+    /// URL).
+    ///
+    /// Recomputes `search_ranges` on every keystroke and immediately
+    /// advances to the nearest match at or after wherever the user is
+    /// currently scrolled to (wrapping to the first match if there is none
+    /// after that point), mirroring how a normal "find in page" behaves.
+    /// Recomputation and the resulting scroll are both cheap (see
+    /// `CommonMarkCache::scroll_to_active_search_match`'s docs: this never
+    /// forces a full document re-render), so this shoud stay responsive.
+    pub fn update_search_matches(&mut self, egui_source_id: &str, content: &str) {
+        self.search_ranges.clear();
+        if !self.search_query.is_empty() {
+            let query = self.search_query.to_lowercase();
+            // Mirror the options CommonMarkViewer itself parses with,
+            // including heading attributes since `enable_scroll_to_heading`
+            // is set below (otherwise `{#section-500}` would remain in the
+            // heading's Text event and get matched too).
+            let options = pulldown_cmark::Options::ENABLE_STRIKETHROUGH
+                | pulldown_cmark::Options::ENABLE_TASKLISTS
+                | pulldown_cmark::Options::ENABLE_TABLES
+                | pulldown_cmark::Options::ENABLE_FOOTNOTES
+                | pulldown_cmark::Options::ENABLE_HEADING_ATTRIBUTES;
+            let parser = pulldown_cmark::Parser::new_ext(content, options).into_offset_iter();
+            for (event, range) in parser {
+                let (pulldown_cmark::Event::Text(text) | pulldown_cmark::Event::Code(text)) = event
+                else {
+                    continue;
+                };
+                let haystack = text.to_lowercase();
+                let mut start = 0;
+                while let Some(pos) = haystack[start..].find(&query) {
+                    let match_start = range.start + start + pos;
+                    let match_end = match_start + query.len();
+                    self.search_ranges.push(match_start..match_end);
+                    start += pos + query.len();
+                }
+            }
+        }
+
+        if self.search_ranges.is_empty() {
+            self.active_match = None;
+            self.sync_active_match();
+            return;
+        }
+
+        let cursor = self.viewport_start_byte_offset(egui_source_id).unwrap_or(0);
+        dbg!(cursor);
+        let nearest = self
+            .search_ranges
+            .iter()
+            .position(|r| r.start >= cursor)
+            .unwrap_or(0);
+        self.active_match = Some(nearest);
+        self.sync_active_match();
+        self.scroll_to_active_search_match();
+    }
+
+    // Update the active search range to the desired ordinal value
+    fn sync_active_match(&mut self) {
+        self.set_active_search_range(
+            self.active_match
+                .and_then(|i| self.search_ranges.get(i))
+                .cloned(),
+        );
+    }
+
+    /// Scroll back or forward `delta` matches (according to the sign of `delta`) if applicable
+    pub fn go_to_match(&mut self, delta: isize) {
+        if self.search_ranges.is_empty() {
+            return;
+        }
+        let len = self.search_ranges.len() as isize;
+        let next = match self.active_match {
+            Some(i) => (i as isize + delta).rem_euclid(len),
+            // First navigation after a fresh search: start at the first
+            // match for Next, the last one for Previous.
+            None if delta >= 0 => 0,
+            None => len - 1,
+        };
+        self.active_match = Some(next as usize);
+        self.sync_active_match();
+        self.scroll_to_active_search_match();
+    }
+
     /// Clear the cache for all scrollable elements
     pub fn clear_scrollable(&mut self) {
         self.scroll.clear();

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -1008,11 +1008,11 @@ impl CommonMarkCache {
         }
     }
 
-    /// After show_scrollable the viewer has applied any pending scroll
-    /// delta and updated the byte-offset tracker.  Sync active_match
+    /// After `show_scrollable` the viewer has applied any pending scroll
+    /// delta and updated the byte-offset tracker.  Sync `active_match`
     /// whenever the viewport byte offset actually changed AND no search
     /// scroll is still animating.  This fires on every animation frame
-    /// (not just the key-press frame), so even large PageDown jumps
+    /// (not just the key-press frame), so even large `PageDown` jumps
     /// settle to the correct match once the animation completes.
     pub fn sync_scrollable_active_match(
         &mut self,
@@ -1068,15 +1068,15 @@ impl CommonMarkCache {
         if self.search_ranges.is_empty() {
             return;
         }
-        let len = self.search_ranges.len() as isize;
+        let len = self.search_ranges.len().cast_signed();
         let next = match self.active_match {
-            Some(i) => (i as isize + delta).rem_euclid(len),
+            Some(i) => (i.cast_signed() + delta).rem_euclid(len),
             // First navigation after a fresh search: start at the first
             // match for Next, the last one for Previous.
             None if delta >= 0 => 0,
-            None => len - 1,
+            None => len.saturating_sub(1),
         };
-        self.active_match = Some(next as usize);
+        self.active_match = Some(next.cast_unsigned());
         self.sync_active_match();
         self.scroll_to_active_search_match();
         self.search_scroll_protection = 30;
@@ -1204,7 +1204,8 @@ impl CommonMarkCache {
             self.set_scroll_delta(egui::vec2(0.0, delta_y));
         }
 
-        let user_scroll_input = ui.input(|i| i.is_scrolling()) || key_scroll_delta.is_some();
+        let user_scroll_input =
+            ui.input(egui::InputState::is_scrolling) || key_scroll_delta.is_some();
 
         if user_scroll_input {
             self.search_scroll_protection = 0;

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -274,10 +274,10 @@ impl Link {
             (vec![], false)
         } else {
             let intervals = crate::search::chunked_search_intervals(
-                    &chunks,
-                    ranges,
-                    cache.active_search_range(),
-                );
+                &chunks,
+                ranges,
+                cache.active_search_range(),
+            );
             let has_active_match = intervals.iter().any(|(_, is_active)| *is_active);
             (intervals, has_active_match)
         };
@@ -938,7 +938,7 @@ impl CommonMarkCache {
 
         if self.search_ranges.is_empty() {
             self.active_match = None;
-            self.sync_active_match();
+            self.sync_active_search_range();
             return;
         }
 
@@ -948,7 +948,7 @@ impl CommonMarkCache {
             .position(|r| r.start >= anchor)
             .unwrap_or(0);
         self.active_match = Some(nearest);
-        self.sync_active_match();
+        self.sync_active_search_range();
         self.scroll_to_active_search_match();
         // Suppress viewport-sync for ~30 frames so the animation toward the
         // new match is not immediately overridden by the centering drift
@@ -980,7 +980,7 @@ impl CommonMarkCache {
     /// [`show_scrollable`](crate::CommonMarkViewer::show_scrollable),
     /// use [`sync_scrollable_active_match`](Self::sync_scrollable_active_match)
     /// instead (see the `scroll` example).
-    pub fn sync_active_match_to_viewport(&mut self, user_scrolled: bool) {
+    pub fn sync_active_match(&mut self, user_scrolled: bool) {
         if user_scrolled {
             self.search_scroll_protection = 0;
         }
@@ -1007,8 +1007,7 @@ impl CommonMarkCache {
             .unwrap_or(len - 1);
         if self.active_match != Some(nearest) {
             self.active_match = Some(nearest);
-            // dbg!(&self.active_match);
-            self.sync_active_match();
+            self.sync_active_search_range();
             // Do NOT call scroll_to_active_search_match: the viewport is
             // already where the user put it.
         }
@@ -1027,7 +1026,7 @@ impl CommonMarkCache {
         user_scrolled: bool,
     ) {
         if !viewport_cache {
-            self.sync_active_match_to_viewport(user_scrolled);
+            self.sync_active_match(user_scrolled);
             return;
         }
 
@@ -1048,7 +1047,7 @@ impl CommonMarkCache {
             };
             if self.active_match() != Some(nearest) {
                 self.active_match = Some(nearest);
-                self.sync_active_match();
+                self.sync_active_search_range();
                 // Do NOT call scroll_to_active_search_match here: the
                 // viewport is already where the user put it.
             }
@@ -1061,7 +1060,7 @@ impl CommonMarkCache {
     }
 
     // Update the active search range to the desired ordinal value
-    fn sync_active_match(&mut self) {
+    fn sync_active_search_range(&mut self) {
         self.set_active_search_range(
             self.active_match
                 .and_then(|i| self.search_ranges.get(i))
@@ -1083,7 +1082,7 @@ impl CommonMarkCache {
             None => len.saturating_sub(1),
         };
         self.active_match = Some(next.cast_unsigned());
-        self.sync_active_match();
+        self.sync_active_search_range();
         self.scroll_to_active_search_match();
         self.search_scroll_protection = 30;
     }

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -48,6 +48,15 @@ pub struct CommonMarkOptions<'f> {
     /// `None`, a theme-derived default is used (see
     /// [`crate::search::default_active_match_bg`]).
     pub search_active_match_bg: Option<egui::Color32>,
+    /// When set via [`show_with_id`](crate::CommonMarkViewer::show_with_id),
+    /// `full_render` records block-boundary positions (split points) under
+    /// this id so that
+    /// [`viewport_start_byte_offset`](CommonMarkCache::viewport_start_byte_offset)
+    /// works and
+    /// [`update_search_matches`](CommonMarkCache::update_search_matches) can
+    /// anchor new searches to the current viewport position.
+    /// Not used by `show_scrollable`, which carries its own source id.
+    pub source_id: Option<egui::Id>,
 }
 
 impl std::fmt::Debug for CommonMarkOptions<'_> {
@@ -72,6 +81,7 @@ impl std::fmt::Debug for CommonMarkOptions<'_> {
             .field("mutable", &self.mutable)
             .field("search_match_bg", &self.search_match_bg)
             .field("search_active_match_bg", &self.search_active_match_bg)
+            .field("source_id", &self.source_id)
             .finish()
     }
 }
@@ -97,6 +107,7 @@ impl Default for CommonMarkOptions<'_> {
             use_viewport_cache: false,
             search_match_bg: None,
             search_active_match_bg: None,
+            source_id: None,
         }
     }
 }
@@ -892,7 +903,14 @@ impl CommonMarkCache {
     /// after that point), mirroring how a normal "find in page" behaves.
     /// Recomputation and the resulting scroll are both cheap (see
     /// `CommonMarkCache::scroll_to_active_search_match`'s docs: this never
-    /// forces a full document re-render), so this shoud stay responsive.
+    /// forces a full document re-render), so this should stay responsive.
+    ///
+    /// Anchoring to the current viewport position requires the viewer to be
+    /// shown via [`show_with_id`](crate::CommonMarkViewer::show_with_id) or
+    /// [`show_scrollable`](crate::CommonMarkViewer::show_scrollable) with the
+    /// same `egui_source_id`. When using plain
+    /// [`show`](crate::CommonMarkViewer::show), the search always starts from
+    /// the document top.
     pub fn update_search_matches(&mut self, egui_source_id: &str, content: &str) {
         // Anchor to the byte position of the currently active match so that
         // adding/removing characters from the query stays on the same spot.

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -568,16 +568,6 @@ fn default_theme(ui: &Ui) -> &str {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum ScrollAction {
-    LineUp,
-    LineDown,
-    PageUp,
-    PageDown,
-    DocTop,
-    DocBottom,
-}
-
 /// A cache used for storing content such as images.
 #[derive(Debug)]
 pub struct CommonMarkCache {
@@ -611,6 +601,10 @@ pub struct CommonMarkCache {
     search_match_virtual_ys: Vec<f32>,
     /// The y position of the top of the last viewport, relative to the document
     last_viewport_virtual_top_y: f32,
+    /// The byte offset of the last viewport, relative to the document, for
+    /// use with `show_scrollable`. Used to detect viewport movement without
+    /// relying on input events.
+    last_viewport_offset: usize,
     /// Counts down after a search-initiated scroll (`go_to_match` /
     /// `update_search_matches`) to prevent viewport-driven active-match
     /// updates from overriding the scroll animation. Cleared immediately
@@ -646,6 +640,7 @@ impl Default for CommonMarkCache {
             active_search_range: None,
             search_match_virtual_ys: Vec::new(),
             last_viewport_virtual_top_y: 0.0,
+            last_viewport_offset: 0,
             search_scroll_protection: 0,
             active_match: None,
             pending_scroll_to_active_match: false,
@@ -893,6 +888,19 @@ impl CommonMarkCache {
     /// `CommonMarkCache::scroll_to_active_search_match`'s docs: this never
     /// forces a full document re-render), so this shoud stay responsive.
     pub fn update_search_matches(&mut self, egui_source_id: &str, content: &str) {
+        // Anchor to the byte position of the currently active match so that
+        // adding/removing characters from the query stays on the same spot.
+        // Fall back to the viewport position for a fresh (no active match)
+        // search.  Using viewport_start here on a query change would jump
+        // backwards whenever the viewport centre is a couple of sections
+        // before the active match (i.e. the match is centred on screen).
+        let anchor = self
+            .active_match
+            .and_then(|i| self.search_ranges.get(i))
+            .map(|r| r.start)
+            .or_else(|| self.viewport_start_byte_offset(egui_source_id))
+            .unwrap_or(0);
+
         self.search_ranges.clear();
         if !self.search_query.is_empty() {
             let query = self.search_query.to_lowercase();
@@ -928,15 +936,17 @@ impl CommonMarkCache {
             return;
         }
 
-        let cursor = self.viewport_start_byte_offset(egui_source_id).unwrap_or(0);
         let nearest = self
             .search_ranges
             .iter()
-            .position(|r| r.start >= cursor)
+            .position(|r| r.start >= anchor)
             .unwrap_or(0);
         self.active_match = Some(nearest);
         self.sync_active_match();
         self.scroll_to_active_search_match();
+        // Suppress viewport-sync for ~30 frames so the animation toward the
+        // new match is not immediately overridden by the centering drift
+        // (viewport start lands before the active match when centred on screen).
         self.search_scroll_protection = 30;
     }
 
@@ -962,7 +972,7 @@ impl CommonMarkCache {
     ///
     /// For documents displayed with
     /// [`show_scrollable`](crate::CommonMarkViewer::show_scrollable),
-    /// use [`viewport_start_byte_offset`](Self::viewport_start_byte_offset)
+    /// use [`sync_scrollable_active_match`](Self::sync_scrollable_active_match)
     /// instead (see the `scroll` example).
     pub fn sync_active_match_to_viewport(&mut self, user_scrolled: bool) {
         if user_scrolled {
@@ -975,6 +985,13 @@ impl CommonMarkCache {
         if self.search_ranges.is_empty() || self.search_match_virtual_ys.is_empty() {
             return;
         }
+
+        // Removed to allow active search to resume from first visible match
+        // (which becomes the active match) after a jump to a heading.
+        // if !user_scrolled {
+        //     return;
+        // }
+
         let vt = self.last_viewport_virtual_top_y;
         let len = self.search_match_virtual_ys.len();
         let nearest = self
@@ -984,9 +1001,56 @@ impl CommonMarkCache {
             .unwrap_or(len - 1);
         if self.active_match != Some(nearest) {
             self.active_match = Some(nearest);
+            // dbg!(&self.active_match);
             self.sync_active_match();
             // Do NOT call scroll_to_active_search_match: the viewport is
             // already where the user put it.
+        }
+    }
+
+    /// After show_scrollable the viewer has applied any pending scroll
+    /// delta and updated the byte-offset tracker.  Sync active_match
+    /// whenever the viewport byte offset actually changed AND no search
+    /// scroll is still animating.  This fires on every animation frame
+    /// (not just the key-press frame), so even large PageDown jumps
+    /// settle to the correct match once the animation completes.
+    pub fn sync_scrollable_active_match(
+        &mut self,
+        egui_source_id: &str,
+        viewport_cache: bool,
+        user_scrolled: bool,
+    ) {
+        if !viewport_cache {
+            self.sync_active_match_to_viewport(user_scrolled);
+            return;
+        }
+
+        let current_offset = self.viewport_start_byte_offset(egui_source_id).unwrap_or(0);
+
+        if !self.search_ranges().is_empty()
+            && self.search_scroll_protection == 0
+            && current_offset != self.last_viewport_offset
+        {
+            let len = self.search_ranges().len();
+            let idx = self
+                .search_ranges()
+                .partition_point(|r| r.start < current_offset);
+            let nearest = if idx > 0 {
+                idx - 1
+            } else {
+                len.saturating_sub(1)
+            };
+            if self.active_match() != Some(nearest) {
+                self.active_match = Some(nearest);
+                self.sync_active_match();
+                // Do NOT call scroll_to_active_search_match here: the
+                // viewport is already where the user put it.
+            }
+        }
+
+        self.last_viewport_offset = current_offset;
+        if self.search_scroll_protection > 0 {
+            self.search_scroll_protection -= 1;
         }
     }
 
@@ -1101,53 +1165,52 @@ impl CommonMarkCache {
     /// Handles keyboard scrolling input and updates cache delta.
     /// Returns `true` if any explicit user scrolling (wheel or keyboard) occurred.
     pub fn handle_keyboard_scrolling(&mut self, ui: &egui::Ui) -> bool {
-        let scroll_action = ui.ctx().input(|i| {
-            use egui::Key;
-            if i.key_pressed(Key::Home) || (i.modifiers.command && i.key_pressed(Key::ArrowUp)) {
-                Some(ScrollAction::DocTop)
-            } else if i.key_pressed(Key::End)
-                || (i.modifiers.command && i.key_pressed(Key::ArrowDown))
-            {
-                Some(ScrollAction::DocBottom)
-            } else if i.key_pressed(Key::PageUp) {
-                Some(ScrollAction::PageUp)
-            } else if i.key_pressed(Key::PageDown) {
-                Some(ScrollAction::PageDown)
-            } else if !i.modifiers.command && i.key_pressed(Key::ArrowUp) {
-                Some(ScrollAction::LineUp)
-            } else if !i.modifiers.command && i.key_pressed(Key::ArrowDown) {
-                Some(ScrollAction::LineDown)
-            } else {
-                None
-            }
-        });
-
         let no_text_focus = !ui.ctx().egui_wants_keyboard_input();
-        let key_scrolled = no_text_focus && scroll_action.is_some();
 
-        if key_scrolled {
-            if let Some(action) = scroll_action {
-                let line_h = ui.text_style_height(&egui::TextStyle::Body);
-                let page_h = ui.available_height();
+        // Calculate line and page heights up front
+        let line_h = ui.text_style_height(&egui::TextStyle::Body);
+        let page_h = ui.available_height();
 
-                let delta_y = match action {
-                    ScrollAction::LineUp => line_h,
-                    ScrollAction::LineDown => -line_h,
-                    ScrollAction::PageUp => page_h,
-                    ScrollAction::PageDown => -page_h,
-                    ScrollAction::DocTop => f32::MAX / 2.0,
-                    ScrollAction::DocBottom => -f32::MAX / 2.0,
-                };
+        // Map key inputs directly to vertical scroll offsets (f32)
+        let key_scroll_delta = no_text_focus
+            .then(|| {
+                ui.ctx().input(|i| {
+                    use egui::Key;
+                    if i.key_pressed(Key::Home)
+                        || (i.modifiers.command && i.key_pressed(Key::ArrowUp))
+                    {
+                        Some(f32::MAX / 2.0)
+                    } else if i.key_pressed(Key::End)
+                        || (i.modifiers.command && i.key_pressed(Key::ArrowDown))
+                    {
+                        Some(-f32::MAX / 2.0)
+                    } else if i.key_pressed(Key::PageUp) {
+                        Some(page_h)
+                    } else if i.key_pressed(Key::PageDown) {
+                        Some(-page_h)
+                    } else if !i.modifiers.command && i.key_pressed(Key::ArrowUp) {
+                        Some(line_h)
+                    } else if !i.modifiers.command && i.key_pressed(Key::ArrowDown) {
+                        Some(-line_h)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .flatten();
 
-                self.set_scroll_delta(egui::vec2(0.0, delta_y));
-            }
+        // Apply scroll delta if a key was pressed
+        if let Some(delta_y) = key_scroll_delta {
+            self.set_scroll_delta(egui::vec2(0.0, delta_y));
         }
 
-        let user_scroll_input = ui.input(|i| i.is_scrolling()) || key_scrolled;
+        let user_scroll_input = ui.input(|i| i.is_scrolling()) || key_scroll_delta.is_some();
+
         if user_scroll_input {
             self.search_scroll_protection = 0;
         }
 
+        // Return combined user scroll status
         user_scroll_input
     }
 }

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -36,6 +36,10 @@ pub struct CommonMarkOptions<'f> {
     /// Whether to enable scrolling to headings by their ID.
     /// To give a heading an ID, use the syntax `# Heading {#myheadingid}`. Then links to `#myheadingid` e.g. `[click me!](#myheadingid)` will scroll to that heading.
     pub enable_scroll_to_heading: bool,
+    /// When `true`, `show_scrollable` only renders the visible slice of the
+    /// document each frame. When `false` (the default) the full document is
+    /// rendered every frame and egui clips what is off-screen.
+    pub use_viewport_cache: bool,
 }
 
 impl std::fmt::Debug for CommonMarkOptions<'_> {
@@ -80,6 +84,7 @@ impl Default for CommonMarkOptions<'_> {
             math_fn: None,
             html_fn: None,
             enable_scroll_to_heading: false,
+            use_viewport_cache: false,
         }
     }
 }
@@ -458,6 +463,9 @@ pub struct CommonMarkCache {
 
     scroll: HashMap<egui::Id, ScrollableCache>,
     pub(self) has_installed_loaders: bool,
+    /// Keyboard / programmatic scroll delta applied inside the next
+    /// `show_scrollable` call and then cleared.
+    pub pending_scroll_delta: egui::Vec2,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -472,6 +480,7 @@ impl Default for CommonMarkCache {
             scroll: Default::default(),
             scroll_to_id_target: None,
             has_installed_loaders: false,
+            pending_scroll_delta: egui::Vec2::ZERO,
         }
     }
 }
@@ -531,6 +540,19 @@ impl CommonMarkCache {
     /// Get mutable access to the desired fragment. Setting this will cause the viewer to scroll to the heading with this id if it exists. Setting it to None will prevent scrolling.
     pub fn scroll_to_id_target_mut(&mut self) -> &mut Option<String> {
         &mut self.scroll_to_id_target
+    }
+
+    /// Accumulate a scroll delta to be applied inside the next [`show_scrollable`] call
+    /// and then cleared. Positive y scrolls toward the top; negative toward the bottom.
+    /// Multiple calls before the next frame are summed.
+    ///
+    /// This is the preferred way to drive keyboard or programmatic scrolling when using
+    /// [`show_scrollable`], because the scroll area is owned internally and cannot be
+    /// reached directly by the caller.
+    ///
+    /// [`show_scrollable`]: crate::CommonMarkViewer::show_scrollable
+    pub fn set_scroll_delta(&mut self, delta: egui::Vec2) {
+        self.pending_scroll_delta += delta;
     }
 
     /// Clear the cache for all scrollable elements

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -41,6 +41,13 @@ pub struct CommonMarkOptions<'f> {
     /// document each frame. When `false` (the default) the full document is
     /// rendered every frame and egui clips what is off-screen.
     pub use_viewport_cache: bool,
+    /// Background colour for passive search matches. When `None`, a
+    /// theme-derived default is used (see [`crate::search::default_match_bg`]).
+    pub search_match_bg: Option<egui::Color32>,
+    /// Background colour for the active (focused) search match. When
+    /// `None`, a theme-derived default is used (see
+    /// [`crate::search::default_active_match_bg`]).
+    pub search_active_match_bg: Option<egui::Color32>,
 }
 
 impl std::fmt::Debug for CommonMarkOptions<'_> {
@@ -63,6 +70,8 @@ impl std::fmt::Debug for CommonMarkOptions<'_> {
             )
             .field("alerts", &self.alerts)
             .field("mutable", &self.mutable)
+            .field("search_match_bg", &self.search_match_bg)
+            .field("search_active_match_bg", &self.search_active_match_bg)
             .finish()
     }
 }
@@ -86,6 +95,8 @@ impl Default for CommonMarkOptions<'_> {
             html_fn: None,
             enable_scroll_to_heading: false,
             use_viewport_cache: false,
+            search_match_bg: None,
+            search_active_match_bg: None,
         }
     }
 }
@@ -114,6 +125,20 @@ impl CommonMarkOptions<'_> {
         } else {
             max_width
         }
+    }
+
+    /// The background colour to use for passive search matches: the
+    /// explicit override if one was set, otherwise a theme-derived default.
+    pub fn search_match_bg(&self, ui: &Ui) -> egui::Color32 {
+        self.search_match_bg
+            .unwrap_or_else(|| crate::search::default_match_bg(ui.visuals()))
+    }
+
+    /// The background colour to use for the active search match: the
+    /// explicit override if one was set, otherwise a theme-derived default.
+    pub fn search_active_match_bg(&self, ui: &Ui) -> egui::Color32 {
+        self.search_active_match_bg
+            .unwrap_or_else(|| crate::search::default_active_match_bg(ui.visuals()))
     }
 }
 
@@ -264,8 +289,8 @@ impl Link {
             crate::search::apply_search_highlights(
                 &mut layout_job,
                 &intervals,
-                crate::search::default_match_bg(),
-                crate::search::default_active_match_bg(),
+                options.search_match_bg(ui),
+                options.search_active_match_bg(ui),
             );
         }
 
@@ -407,8 +432,8 @@ impl CodeBlock {
                     crate::search::apply_search_highlights(
                         &mut job,
                         &intervals,
-                        crate::search::default_match_bg(),
-                        crate::search::default_active_match_bg(),
+                        options.search_match_bg(ui),
+                        options.search_active_match_bg(ui),
                     );
                 }
 
@@ -685,6 +710,21 @@ impl CommonMarkCache {
     /// The search match ranges currently set for highlighting.
     pub fn search_ranges(&self) -> &[Range<usize>] {
         &self.search_ranges
+    }
+
+    /// Approximate the source byte offset of whatever is currently at the
+    /// top of the viewport for the given [`show_scrollable`](crate::CommonMarkViewer::show_scrollable)
+    /// instance. Useful for implementing "search from the current position"
+    /// (like a typical find-in-page: jump to the nearest match at or after
+    /// what's currently on screen, instead of always restarting from the top
+    /// of the document).
+    ///
+    /// Returns `None` if nothing has been rendered for `source_id` yet, or
+    /// if it was rendered with [`viewport_cache`](crate::CommonMarkViewer::viewport_cache)
+    /// disabled (in which case the whole document is visible-ish anyway).
+    pub fn viewport_start_byte_offset(&self, source_id: impl egui::AsId) -> Option<usize> {
+        let sc = self.scroll.get(&egui::Id::new(source_id))?;
+        sc.byte_offset_for_virtual_y(sc.last_viewport_top_y)
     }
 
     /// Set the active (focused) search match, which is highlighted more

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -689,8 +689,9 @@ impl CommonMarkCache {
         &mut self.scroll_to_id_target
     }
 
-    /// Accumulate a scroll delta to be applied inside the next [`show_scrollable`] call
-    /// and then cleared. Positive y scrolls toward the top; negative toward the bottom.
+    /// Accumulate a scroll delta to be applied inside the next [`show_scrollable`] or
+    /// [`apply_pending_scroll_delta`] call and then cleared.
+    /// Positive y scrolls toward the top; negative toward the bottom.
     /// Multiple calls before the next frame are summed.
     ///
     /// This is the preferred way to drive keyboard or programmatic scrolling when using
@@ -700,6 +701,15 @@ impl CommonMarkCache {
     /// [`show_scrollable`]: crate::CommonMarkViewer::show_scrollable
     pub fn set_scroll_delta(&mut self, delta: egui::Vec2) {
         self.pending_scroll_delta += delta;
+    }
+
+    /// To apply scrolling without `show_scrollable`, call this function immediately before
+    /// or after `show`.
+    pub fn apply_pending_scroll_delta(&mut self, ui: &Ui) {
+        let delta = std::mem::replace(&mut self.pending_scroll_delta, egui::Vec2::ZERO);
+        if delta != egui::Vec2::ZERO {
+            ui.scroll_with_delta(delta);
+        }
     }
 
     /// Set the byte ranges (into the source text passed to the viewer) that

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -1,6 +1,7 @@
 use crate::alerts::AlertBundle;
 use egui::{RichText, TextBuffer, TextStyle, Ui, text::LayoutJob};
 use std::collections::HashMap;
+use std::ops::Range;
 
 use crate::pulldown::ScrollableCache;
 
@@ -300,19 +301,49 @@ impl Image {
     }
 }
 
+#[derive(Default)]
 pub struct CodeBlock {
     pub lang: Option<String>,
     pub content: String,
+    /// For each chunk of text appended to `content` (one per markdown text
+    /// event), the local byte range within `content` paired with its byte
+    /// range in the original source text. Used to translate global search
+    /// match ranges into positions local to this code block.
+    pub chunks: Vec<(Range<usize>, Range<usize>)>,
 }
 
 impl CodeBlock {
+    /// Append a chunk of text to the code block's content, recording its
+    /// source span so search matches can later be mapped back onto it.
+    pub fn push_text(&mut self, text: &str, src_span: Range<usize>) {
+        let start = self.content.len();
+        self.content.push_str(text);
+        self.chunks.push((start..self.content.len(), src_span));
+    }
+
+    /// Renders the code block. If `want_scroll_to_active_match` is true and
+    /// the currently active search match falls inside this block, the view
+    /// is scrolled (centering the match) and `true` is returned so the
+    /// caller knows the request has been fulfilled.
     pub fn end(
         &self,
         ui: &mut Ui,
         cache: &mut CommonMarkCache,
         options: &CommonMarkOptions,
         max_width: f32,
-    ) {
+        want_scroll_to_active_match: bool,
+    ) -> bool {
+        let intervals = crate::search::code_block_search_intervals(
+            &self.chunks,
+            cache.search_ranges(),
+            cache.active_search_range(),
+        );
+        let scroll_to_active_match = want_scroll_to_active_match
+            .then(|| intervals.iter().find(|(_, is_active)| *is_active))
+            .flatten()
+            .map(|(range, _)| range.clone());
+        let did_scroll = scroll_to_active_match.is_some();
+
         ui.scope(|ui| {
             Self::pre_syntax_highlighting(cache, options, ui);
 
@@ -323,12 +354,29 @@ impl CodeBlock {
                     plain_highlighting(ui, string.as_str())
                 };
 
+                if !intervals.is_empty() {
+                    crate::search::apply_search_highlights(
+                        &mut job,
+                        &intervals,
+                        crate::search::default_match_bg(),
+                        crate::search::default_active_match_bg(),
+                    );
+                }
+
                 job.wrap.max_width = wrap_width;
                 ui.fonts_mut(|f| f.layout_job(job))
             };
 
-            crate::elements::code_block(ui, max_width, &self.content, &mut layout);
+            crate::elements::code_block(
+                ui,
+                max_width,
+                &self.content,
+                &mut layout,
+                scroll_to_active_match,
+            );
         });
+
+        did_scroll
     }
 }
 
@@ -466,6 +514,16 @@ pub struct CommonMarkCache {
     /// Keyboard / programmatic scroll delta applied inside the next
     /// `show_scrollable` call and then cleared.
     pub pending_scroll_delta: egui::Vec2,
+
+    /// Byte ranges (into the source text passed to the viewer) that should
+    /// be highlighted as search matches.
+    search_ranges: Vec<Range<usize>>,
+    /// The currently active (focused) search match, highlighted more
+    /// prominently than the others.
+    active_search_range: Option<Range<usize>>,
+    /// Set by [`CommonMarkCache::scroll_to_active_search_match`] and cleared
+    /// once the render pass that finds and scrolls to the active match runs.
+    pending_scroll_to_active_match: bool,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -481,6 +539,9 @@ impl Default for CommonMarkCache {
             scroll_to_id_target: None,
             has_installed_loaders: false,
             pending_scroll_delta: egui::Vec2::ZERO,
+            search_ranges: Vec::new(),
+            active_search_range: None,
+            pending_scroll_to_active_match: false,
         }
     }
 }
@@ -553,6 +614,58 @@ impl CommonMarkCache {
     /// [`show_scrollable`]: crate::CommonMarkViewer::show_scrollable
     pub fn set_scroll_delta(&mut self, delta: egui::Vec2) {
         self.pending_scroll_delta += delta;
+    }
+
+    /// Set the byte ranges (into the source text passed to the viewer) that
+    /// should be highlighted as search matches. Ranges must fall on valid
+    /// UTF-8 character boundaries.
+    ///
+    /// This is cheap to call every frame (e.g. while the user is typing into
+    /// a search box): highlighting never changes the number of widgets that
+    /// get rendered, so it cannot desync egui's widget IDs.
+    pub fn set_search_ranges(&mut self, ranges: Vec<Range<usize>>) {
+        self.search_ranges = ranges;
+    }
+
+    /// The search match ranges currently set for highlighting.
+    pub fn search_ranges(&self) -> &[Range<usize>] {
+        &self.search_ranges
+    }
+
+    /// Set the active (focused) search match, which is highlighted more
+    /// prominently than the other matches. Pass `None` to clear it.
+    ///
+    /// This does not by itself scroll the view; call
+    /// [`scroll_to_active_search_match`](Self::scroll_to_active_search_match)
+    /// as well if you want that (typically when the user moves to the next/
+    /// previous match).
+    pub fn set_active_search_range(&mut self, range: Option<Range<usize>>) {
+        self.active_search_range = range;
+    }
+
+    /// The currently active (focused) search match, if any.
+    pub fn active_search_range(&self) -> Option<&Range<usize>> {
+        self.active_search_range.as_ref()
+    }
+
+    /// Request that the view scroll so that the active search match (set via
+    /// [`set_active_search_range`](Self::set_active_search_range)) becomes
+    /// visible, centered in the viewport where possible. The request is
+    /// consumed by the next render.
+    pub fn scroll_to_active_search_match(&mut self) {
+        self.pending_scroll_to_active_match = true;
+    }
+
+    /// Whether a scroll to the active search match is pending. Used
+    /// internally to decide whether a cached viewport render needs to be
+    /// refreshed in full in order to locate the match.
+    pub fn has_pending_scroll_to_active_match(&self) -> bool {
+        self.pending_scroll_to_active_match
+    }
+
+    /// Takes (and clears) the pending scroll-to-active-match request.
+    pub fn take_pending_scroll_to_active_match(&mut self) -> bool {
+        std::mem::take(&mut self.pending_scroll_to_active_match)
     }
 
     /// Clear the cache for all scrollable elements

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -597,6 +597,15 @@ pub struct CommonMarkCache {
     /// The currently active (focused) search match, highlighted more
     /// prominently than the others.
     active_search_range: Option<Range<usize>>,
+    /// The y positions of the search matches, relative to the document
+    search_match_virtual_ys: Vec<f32>,
+    /// The y position of the top of the last viewport, relative to the document
+    last_viewport_virtual_top_y: f32,
+    /// Counts down after a search-initiated scroll (`go_to_match` /
+    /// `update_search_matches`) to prevent viewport-driven active-match
+    /// updates from overriding the scroll animation. Cleared immediately
+    /// when the user scrolls manually.
+    search_scroll_protection: u32,
     /// The ordinal number of the active search match
     active_match: Option<usize>,
     /// Set by [`CommonMarkCache::scroll_to_active_search_match`] and cleared
@@ -625,6 +634,9 @@ impl Default for CommonMarkCache {
             search_query: String::new(),
             search_ranges: Vec::new(),
             active_search_range: None,
+            search_match_virtual_ys: Vec::new(),
+            last_viewport_virtual_top_y: 0.0,
+            search_scroll_protection: 0,
             active_match: None,
             pending_scroll_to_active_match: false,
             pending_scroll_to_active_match_retries: 0,
@@ -759,6 +771,58 @@ impl CommonMarkCache {
         self.active_search_range.as_ref()
     }
 
+    /// The virtual-y (content-relative, scroll-independent) position of the
+    /// top of each search match's rendered rect, updated every frame by
+    /// [`show`](crate::CommonMarkViewer::show). Index-parallel to
+    /// [`search_ranges`](Self::search_ranges).
+    ///
+    /// Combined with [`last_viewport_virtual_top_y`](Self::last_viewport_virtual_top_y),
+    /// this lets you determine which matches were above, inside, and below
+    /// the viewport after the user scrolls — use it to update the active
+    /// match in the same way [`scroll.rs`] does via `viewport_start_byte_offset`.
+    ///
+    /// Values are 0.0 for any match whose containing text run has not yet
+    /// been rendered, and are only meaningful for the `show()` path (not
+    /// `show_scrollable`).
+    pub fn search_match_virtual_ys(&self) -> &[f32] {
+        &self.search_match_virtual_ys
+    }
+
+    /// The virtual-y of the top of the viewport as recorded by the most
+    /// recent [`show`](crate::CommonMarkViewer::show) call (0.0 before the
+    /// first call). "Virtual" means content-relative and scroll-independent:
+    /// it equals the current scroll offset from the top of the document.
+    ///
+    /// Compare against [`search_match_virtual_ys`](Self::search_match_virtual_ys)
+    /// to find the last match above (or first match at-or-after) the
+    /// current scroll position.
+    pub fn last_viewport_virtual_top_y(&self) -> f32 {
+        self.last_viewport_virtual_top_y
+    }
+
+    /// Updates the per-match virtual-y positions and the viewport top-y
+    /// recorded during a [`show`](crate::CommonMarkViewer::show) call.
+    /// `match_ys` is an iterator of `(match_index, virtual_y)` pairs.
+    ///
+    /// Used internally by the renderer; read the results via
+    /// [`search_match_virtual_ys`](Self::search_match_virtual_ys) and
+    /// [`last_viewport_virtual_top_y`](Self::last_viewport_virtual_top_y).
+    pub fn update_show_viewport(
+        &mut self,
+        match_ys: impl IntoIterator<Item = (usize, f32)>,
+        viewport_top_y: f32,
+    ) {
+        let n = self.search_ranges.len();
+        self.search_match_virtual_ys.clear();
+        self.search_match_virtual_ys.resize(n, 0.0);
+        for (idx, y) in match_ys {
+            if idx < n {
+                self.search_match_virtual_ys[idx] = y;
+            }
+        }
+        self.last_viewport_virtual_top_y = viewport_top_y;
+    }
+
     /// The ordinal number of the currently active (focused) search match, if any.
     pub fn active_match(&self) -> Option<usize> {
         self.active_match
@@ -864,6 +928,57 @@ impl CommonMarkCache {
         self.active_match = Some(nearest);
         self.sync_active_match();
         self.scroll_to_active_search_match();
+        self.search_scroll_protection = 30;
+    }
+
+    /// Synchronises the active search match to the current scroll position
+    /// for documents displayed with [`show`](crate::CommonMarkViewer::show).
+    ///
+    /// Call this once per frame immediately after `show()` returns, passing
+    /// `user_scrolled = true` whenever the frame received explicit user
+    /// scroll input (mouse wheel, keyboard arrow/page keys, etc.).
+    ///
+    /// When `user_scrolled` is `true`, any ongoing post-search scroll
+    /// protection is cancelled and the active match re-anchors immediately
+    /// to the top of the viewport. When `false`, the protection counter
+    /// winds down automatically over the following ~30 frames (enough for
+    /// a typical scroll-to-match animation to settle), after which normal
+    /// syncing resumes.
+    ///
+    /// The active match is set to the first match at or after the viewport
+    /// top, so that pressing Next from the current scroll position advances
+    /// to the next unseen match. `scroll_to_active_search_match` is
+    /// deliberately *not* called: the viewport is already where the user
+    /// put it.
+    ///
+    /// For documents displayed with
+    /// [`show_scrollable`](crate::CommonMarkViewer::show_scrollable),
+    /// use [`viewport_start_byte_offset`](Self::viewport_start_byte_offset)
+    /// instead (see the `scroll` example).
+    pub fn sync_active_match_to_viewport(&mut self, user_scrolled: bool) {
+        if user_scrolled {
+            self.search_scroll_protection = 0;
+        }
+        if self.search_scroll_protection > 0 {
+            self.search_scroll_protection -= 1;
+            return;
+        }
+        if self.search_ranges.is_empty() || self.search_match_virtual_ys.is_empty() {
+            return;
+        }
+        let vt = self.last_viewport_virtual_top_y;
+        let len = self.search_match_virtual_ys.len();
+        let nearest = self
+            .search_match_virtual_ys
+            .iter()
+            .position(|&y| y >= vt)
+            .unwrap_or(len - 1);
+        if self.active_match != Some(nearest) {
+            self.active_match = Some(nearest);
+            self.sync_active_match();
+            // Do NOT call scroll_to_active_search_match: the viewport is
+            // already where the user put it.
+        }
     }
 
     // Update the active search range to the desired ordinal value
@@ -891,6 +1006,7 @@ impl CommonMarkCache {
         self.active_match = Some(next as usize);
         self.sync_active_match();
         self.scroll_to_active_search_match();
+        self.search_scroll_protection = 30;
     }
 
     /// Clear the cache for all scrollable elements

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -524,6 +524,11 @@ pub struct CommonMarkCache {
     /// Set by [`CommonMarkCache::scroll_to_active_search_match`] and cleared
     /// once the render pass that finds and scrolls to the active match runs.
     pending_scroll_to_active_match: bool,
+    /// Number of consecutive internal retries (viewport blind-scroll not
+    /// yet having brought the match into a rendered slice). Bounds an
+    /// otherwise-unlikely non-convergent loop; reset whenever the user
+    /// requests a fresh scroll via [`CommonMarkCache::scroll_to_active_search_match`].
+    pending_scroll_to_active_match_retries: u8,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -542,6 +547,7 @@ impl Default for CommonMarkCache {
             search_ranges: Vec::new(),
             active_search_range: None,
             pending_scroll_to_active_match: false,
+            pending_scroll_to_active_match_retries: 0,
         }
     }
 }
@@ -652,20 +658,39 @@ impl CommonMarkCache {
     /// [`set_active_search_range`](Self::set_active_search_range)) becomes
     /// visible, centered in the viewport where possible. The request is
     /// consumed by the next render.
+    ///
+    /// This never forces a full re-render of the document, even in
+    /// [`show_scrollable`](crate::CommonMarkViewer::show_scrollable)'s
+    /// viewport-cached mode: if the match isn't already in the currently
+    /// rendered slice, the view is scrolled toward its approximate position
+    /// (using data already collected by the last full render) and refined
+    /// precisely over the following frame or two as the real slice comes
+    /// into view.
     pub fn scroll_to_active_search_match(&mut self) {
         self.pending_scroll_to_active_match = true;
+        self.pending_scroll_to_active_match_retries = 0;
     }
 
-    /// Whether a scroll to the active search match is pending. Used
-    /// internally to decide whether a cached viewport render needs to be
-    /// refreshed in full in order to locate the match.
-    pub fn has_pending_scroll_to_active_match(&self) -> bool {
-        self.pending_scroll_to_active_match
-    }
-
-    /// Takes (and clears) the pending scroll-to-active-match request.
+    /// Takes (and clears) the pending scroll-to-active-match request. Used
+    /// internally by the renderer.
     pub fn take_pending_scroll_to_active_match(&mut self) -> bool {
         std::mem::take(&mut self.pending_scroll_to_active_match)
+    }
+
+    /// Re-arms the pending scroll-to-active-match request for another
+    /// attempt (the match wasn't in the slice rendered this frame), unless
+    /// the retry budget has been exhausted, in which case the request is
+    /// dropped and `false` is returned. Used internally by the renderer to
+    /// bound an otherwise-unlikely non-convergent blind-scroll loop.
+    pub fn retry_scroll_to_active_match(&mut self) -> bool {
+        const MAX_RETRIES: u8 = 8;
+        if self.pending_scroll_to_active_match_retries >= MAX_RETRIES {
+            self.pending_scroll_to_active_match = false;
+            return false;
+        }
+        self.pending_scroll_to_active_match_retries += 1;
+        self.pending_scroll_to_active_match = true;
+        true
     }
 
     /// Clear the cache for all scrollable elements

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -897,7 +897,7 @@ impl CommonMarkCache {
         // Anchor to the byte position of the currently active match so that
         // adding/removing characters from the query stays on the same spot.
         // Fall back to the viewport position for a fresh (no active match)
-        // search.  Using viewport_start here on a query change would jump
+        // search. Using viewport_start here on a query change would jump
         // backwards whenever the viewport centre is a couple of sections
         // before the active match (i.e. the match is centred on screen).
         let anchor = self

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -201,25 +201,55 @@ impl Style {
 pub struct Link {
     pub destination: String,
     pub text: Vec<RichText>,
+    /// For each accumulated `text` piece, its local byte range within the
+    /// final rendered job's text paired with its byte range in the original
+    /// source. Used to translate global search match ranges into positions
+    /// local to this link's rendered text.
+    pub chunks: Vec<(Range<usize>, Range<usize>)>,
 }
 
 impl Link {
+    /// Append a piece of link text, recording its source span so search
+    /// matches can later be mapped back onto it.
+    pub fn push_text(&mut self, text: RichText, src_span: Range<usize>) {
+        let local_start: usize = self.text.iter().map(|t| t.text().len()).sum();
+        let local_end = local_start + text.text().len();
+        self.chunks.push((local_start..local_end, src_span));
+        self.text.push(text);
+    }
+
+    /// Renders the link. If `want_scroll_to_active_match` is true and the
+    /// currently active search match falls inside this link's text, the view
+    /// is scrolled (centering the link) and `true` is returned so the caller
+    /// knows the request has been fulfilled.
     pub fn end(
         self,
         ui: &mut Ui,
         cache: &mut CommonMarkCache,
         options: &CommonMarkOptions,
         scroll_to_heading: &mut Option<String>,
-    ) {
-        let Self { destination, text } = self;
+        want_scroll_to_active_match: bool,
+    ) -> bool {
+        let Self {
+            destination,
+            text,
+            chunks,
+        } = self;
 
         // When a link wraps an image (`[![alt](img)](url)`), all text events are captured
         // by the image widget and link.text is never populated. Rendering an empty Label in
         // a wrapping layout resets cursor.min.x to 0, superimposing subsequent elements on
         // the image that was just drawn. Nothing to render, so return early.
         if text.is_empty() {
-            return;
+            return false;
         }
+
+        let intervals = crate::search::chunked_search_intervals(
+            &chunks,
+            cache.search_ranges(),
+            cache.active_search_range(),
+        );
+        let has_active_match = intervals.iter().any(|(_, is_active)| *is_active);
 
         let mut layout_job = LayoutJob::default();
         for t in text {
@@ -230,19 +260,38 @@ impl Link {
                 egui::Align::LEFT,
             );
         }
-        if cache.link_hooks().contains_key(&destination) {
+        if !intervals.is_empty() {
+            crate::search::apply_search_highlights(
+                &mut layout_job,
+                &intervals,
+                crate::search::default_match_bg(),
+                crate::search::default_active_match_bg(),
+            );
+        }
+
+        let response = if cache.link_hooks().contains_key(&destination) {
             let ui_link = ui.link(layout_job);
             if ui_link.clicked() || ui_link.middle_clicked() {
                 cache.link_hooks_mut().insert(destination, true);
             }
+            ui_link
         } else if options.enable_scroll_to_heading
             && let Some(stripped) = destination.strip_prefix("#")
         {
-            if ui.link(layout_job).clicked() {
+            let response = ui.link(layout_job);
+            if response.clicked() {
                 scroll_to_heading.replace(stripped.to_string());
             };
+            response
         } else {
-            ui.hyperlink_to(layout_job, destination);
+            ui.hyperlink_to(layout_job, destination)
+        };
+
+        if want_scroll_to_active_match && has_active_match {
+            ui.scroll_to_rect(response.rect, Some(egui::Align::Center));
+            true
+        } else {
+            false
         }
     }
 }
@@ -333,7 +382,7 @@ impl CodeBlock {
         max_width: f32,
         want_scroll_to_active_match: bool,
     ) -> bool {
-        let intervals = crate::search::code_block_search_intervals(
+        let intervals = crate::search::chunked_search_intervals(
             &self.chunks,
             cache.search_ranges(),
             cache.active_search_range(),

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -269,12 +269,18 @@ impl Link {
             return false;
         }
 
-        let intervals = crate::search::chunked_search_intervals(
-            &chunks,
-            cache.search_ranges(),
-            cache.active_search_range(),
-        );
-        let has_active_match = intervals.iter().any(|(_, is_active)| *is_active);
+        let ranges = cache.search_ranges();
+        let (intervals, has_active_match) = if ranges.is_empty() {
+            (vec![], false)
+        } else {
+            let intervals = crate::search::chunked_search_intervals(
+                    &chunks,
+                    ranges,
+                    cache.active_search_range(),
+                );
+            let has_active_match = intervals.iter().any(|(_, is_active)| *is_active);
+            (intervals, has_active_match)
+        };
 
         let mut layout_job = LayoutJob::default();
         for t in text {
@@ -312,7 +318,7 @@ impl Link {
             ui.hyperlink_to(layout_job, destination)
         };
 
-        if want_scroll_to_active_match && has_active_match {
+        if has_active_match && want_scroll_to_active_match {
             ui.scroll_to_rect(response.rect, Some(egui::Align::Center));
             true
         } else {

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -597,6 +597,8 @@ pub struct CommonMarkCache {
     /// The currently active (focused) search match, highlighted more
     /// prominently than the others.
     active_search_range: Option<Range<usize>>,
+    /// The ordinal number of the active search match
+    active_match: Option<usize>,
     /// The y positions of the search matches, relative to the document
     search_match_virtual_ys: Vec<f32>,
     /// The y position of the top of the last viewport, relative to the document
@@ -610,8 +612,6 @@ pub struct CommonMarkCache {
     /// updates from overriding the scroll animation. Cleared immediately
     /// when the user scrolls manually.
     search_scroll_protection: u32,
-    /// The ordinal number of the active search match
-    active_match: Option<usize>,
     /// Set by [`CommonMarkCache::scroll_to_active_search_match`] and cleared
     /// once the render pass that finds and scrolls to the active match runs.
     pending_scroll_to_active_match: bool,
@@ -638,11 +638,11 @@ impl Default for CommonMarkCache {
             search_query: String::new(),
             search_ranges: Vec::new(),
             active_search_range: None,
+            active_match: None,
             search_match_virtual_ys: Vec::new(),
             last_viewport_virtual_top_y: 0.0,
             last_viewport_offset: 0,
             search_scroll_protection: 0,
-            active_match: None,
             pending_scroll_to_active_match: false,
             pending_scroll_to_active_match_retries: 0,
         }

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -783,6 +783,7 @@ impl CommonMarkCache {
     }
 
     /// Clear the cache for all scrollable elements
+    /// Clear the cache for all scrollable elements
     pub fn clear_scrollable(&mut self) {
         self.scroll.clear();
     }

--- a/egui_commonmark_backend/src/misc.rs
+++ b/egui_commonmark_backend/src/misc.rs
@@ -259,6 +259,16 @@ impl Link {
     /// currently active search match falls inside this link's text, the view
     /// is scrolled (centering the link) and `true` is returned so the caller
     /// knows the request has been fulfilled.
+    /// `content_origin_y` is the screen-space Y of the document top for the
+    /// current render pass (as recorded by `CommonMarkViewerInternal`). It is
+    /// subtracted from the link widget's screen Y to produce the virtual
+    /// (scroll-independent) Y stored in `search_match_virtual_ys`.
+    ///
+    /// Returns `(scrolled, match_ys)` where `match_ys` is a list of
+    /// `(global_match_index, virtual_y)` pairs for every search match that
+    /// falls inside this link's text. The caller should extend
+    /// `search_match_ys_scratch` with these so that `sync_active_match` can
+    /// correctly identify which visual row link matches are on.
     pub fn end(
         self,
         ui: &mut Ui,
@@ -266,7 +276,8 @@ impl Link {
         options: &CommonMarkOptions,
         scroll_to_heading: &mut Option<String>,
         want_scroll_to_active_match: bool,
-    ) -> bool {
+        content_origin_y: f32,
+    ) -> (bool, Vec<(usize, f32)>) {
         let Self {
             destination,
             text,
@@ -278,7 +289,7 @@ impl Link {
         // a wrapping layout resets cursor.min.x to 0, superimposing subsequent elements on
         // the image that was just drawn. Nothing to render, so return early.
         if text.is_empty() {
-            return false;
+            return (false, vec![]);
         }
 
         let ranges = cache.search_ranges();
@@ -330,12 +341,34 @@ impl Link {
             ui.hyperlink_to(layout_job, destination)
         };
 
-        if has_active_match && want_scroll_to_active_match {
+        let scrolled = if has_active_match && want_scroll_to_active_match {
             ui.scroll_to_rect(response.rect, Some(egui::Align::Center));
             true
         } else {
             false
-        }
+        };
+
+        // Record the virtual Y for every search match inside this link.
+        // Link text is accumulated and rendered as a single widget, so it
+        // never goes through the `event_text` else-branch that normally
+        // fills `search_match_ys_scratch`. Use the widget's top-left Y
+        // (same row as the surrounding inline text) for all of them.
+        let link_virtual_y = response.rect.min.y - content_origin_y;
+        let link_src_start = chunks
+            .iter()
+            .map(|(_, s)| s.start)
+            .min()
+            .unwrap_or(usize::MAX);
+        let link_src_end = chunks.iter().map(|(_, s)| s.end).max().unwrap_or(0);
+        let match_ys: Vec<(usize, f32)> = cache
+            .search_ranges()
+            .iter()
+            .enumerate()
+            .filter(|(_, r)| r.start < link_src_end && r.end > link_src_start)
+            .map(|(i, _)| (i, link_virtual_y))
+            .collect();
+
+        (scrolled, match_ys)
     }
 }
 
@@ -417,6 +450,11 @@ impl CodeBlock {
     /// the currently active search match falls inside this block, the view
     /// is scrolled (centering the match) and `true` is returned so the
     /// caller knows the request has been fulfilled.
+    ///
+    /// `content_origin_y` is the screen-space Y of the document top (see
+    /// [`Link::end`] for details). Returns `(scrolled, match_ys)` where
+    /// `match_ys` lists `(global_match_index, virtual_y)` for every search
+    /// match in this block so the caller can extend `search_match_ys_scratch`.
     pub fn end(
         &self,
         ui: &mut Ui,
@@ -424,7 +462,8 @@ impl CodeBlock {
         options: &CommonMarkOptions,
         max_width: f32,
         want_scroll_to_active_match: bool,
-    ) -> bool {
+        content_origin_y: f32,
+    ) -> (bool, Vec<(usize, f32)>) {
         let intervals = crate::search::chunked_search_intervals(
             &self.chunks,
             cache.search_ranges(),
@@ -436,39 +475,78 @@ impl CodeBlock {
             .map(|(range, _)| range.clone());
         let did_scroll = scroll_to_active_match.is_some();
 
-        ui.scope(|ui| {
-            Self::pre_syntax_highlighting(cache, options, ui);
+        let (galley_pos, galley) = ui
+            .scope(|ui| {
+                Self::pre_syntax_highlighting(cache, options, ui);
 
-            let mut layout = |ui: &Ui, string: &dyn TextBuffer, wrap_width: f32| {
-                let mut job = if let Some(lang) = &self.lang {
-                    self.syntax_highlighting(cache, options, lang, ui, string.as_str())
-                } else {
-                    plain_highlighting(ui, string.as_str())
+                let mut layout = |ui: &Ui, string: &dyn TextBuffer, wrap_width: f32| {
+                    let mut job = if let Some(lang) = &self.lang {
+                        self.syntax_highlighting(cache, options, lang, ui, string.as_str())
+                    } else {
+                        plain_highlighting(ui, string.as_str())
+                    };
+
+                    if !intervals.is_empty() {
+                        crate::search::apply_search_highlights(
+                            &mut job,
+                            &intervals,
+                            options.search_match_bg(ui),
+                            options.search_active_match_bg(ui),
+                        );
+                    }
+
+                    job.wrap.max_width = wrap_width;
+                    ui.fonts_mut(|f| f.layout_job(job))
                 };
 
-                if !intervals.is_empty() {
-                    crate::search::apply_search_highlights(
-                        &mut job,
-                        &intervals,
-                        options.search_match_bg(ui),
-                        options.search_active_match_bg(ui),
-                    );
-                }
+                crate::elements::code_block(
+                    ui,
+                    max_width,
+                    &self.content,
+                    &mut layout,
+                    scroll_to_active_match,
+                )
+            })
+            .inner;
 
-                job.wrap.max_width = wrap_width;
-                ui.fonts_mut(|f| f.layout_job(job))
-            };
+        // Record the exact virtual Y of each search match by querying the
+        // galley that was just rendered. Unlike the old single block-top Y
+        // approach, this handles code blocks taller than one viewport: a
+        // match partway down a large block gets the Y of its actual line,
+        // not the block top, so the in-viewport check stays correct while
+        // the user scrolls through the block.
+        let match_ys: Vec<(usize, f32)> = self
+            .chunks
+            .iter()
+            .flat_map(|(local_chunk, src_chunk)| {
+                let chunk_text_len = local_chunk.end.saturating_sub(local_chunk.start);
+                cache
+                    .search_ranges()
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, r)| r.start < src_chunk.end && r.end > src_chunk.start)
+                    .filter_map(|(global_idx, r)| {
+                        // Translate source byte range to local range within `content`.
+                        let local_start =
+                            r.start.saturating_sub(src_chunk.start).min(chunk_text_len)
+                                + local_chunk.start;
+                        let local_end = r.end.saturating_sub(src_chunk.start).min(chunk_text_len)
+                            + local_chunk.start;
+                        if local_start >= local_end {
+                            return None;
+                        }
+                        let rect = crate::elements::highlight_rect_for_byte_range(
+                            &galley,
+                            galley_pos,
+                            local_start..local_end,
+                        )?;
+                        Some((global_idx, rect.min.y - content_origin_y))
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
 
-            crate::elements::code_block(
-                ui,
-                max_width,
-                &self.content,
-                &mut layout,
-                scroll_to_active_match,
-            );
-        });
-
-        did_scroll
+        (did_scroll, match_ys)
     }
 }
 
@@ -634,6 +712,10 @@ pub struct CommonMarkCache {
     search_match_virtual_ys: Vec<f32>,
     /// The y position of the top of the last viewport, relative to the document
     last_viewport_virtual_top_y: f32,
+    /// The height of the last viewport (clip rect), in the same virtual
+    /// coordinate space as `last_viewport_virtual_top_y`. Together they form
+    /// the interval `[top, top + height)` that defines what is on screen.
+    last_viewport_height: f32,
     /// The byte offset of the last viewport, relative to the document, for
     /// use with `show_scrollable`. Used to detect viewport movement without
     /// relying on input events.
@@ -643,6 +725,13 @@ pub struct CommonMarkCache {
     /// updates from overriding the scroll animation. Cleared immediately
     /// when the user scrolls manually.
     search_scroll_protection: u32,
+    /// Set by [`go_to_match`](Self::go_to_match) to hold `sync_active_match`
+    /// from overriding the explicitly chosen match until the user next
+    /// scrolls. Unlike `search_scroll_protection` (which counts down and
+    /// expires), this stays latched indefinitely so that multiple matches
+    /// on the same visual line don't snap back to the first one once the
+    /// scroll-protection countdown expires.
+    go_to_match_locked: bool,
     /// Set by [`CommonMarkCache::scroll_to_active_search_match`] and cleared
     /// once the render pass that finds and scrolls to the active match runs.
     pending_scroll_to_active_match: bool,
@@ -674,8 +763,10 @@ impl Default for CommonMarkCache {
             active_match: None,
             search_match_virtual_ys: Vec::new(),
             last_viewport_virtual_top_y: 0.0,
+            last_viewport_height: 0.0,
             last_viewport_offset: 0,
             search_scroll_protection: 0,
+            go_to_match_locked: false,
             pending_scroll_to_active_match: false,
             pending_scroll_to_active_match_retries: 0,
         }
@@ -838,9 +929,11 @@ impl CommonMarkCache {
         self.last_viewport_virtual_top_y
     }
 
-    /// Updates the per-match virtual-y positions and the viewport top-y
+    /// Updates the per-match virtual-y positions and the viewport geometry
     /// recorded during a [`show`](crate::CommonMarkViewer::show) call.
     /// `match_ys` is an iterator of `(match_index, virtual_y)` pairs.
+    /// `viewport_height` is the height of the clip rect (same coordinate
+    /// space as `viewport_top_y`).
     ///
     /// Used internally by the renderer; read the results via
     /// [`search_match_virtual_ys`](Self::search_match_virtual_ys) and
@@ -849,6 +942,7 @@ impl CommonMarkCache {
         &mut self,
         match_ys: impl IntoIterator<Item = (usize, f32)>,
         viewport_top_y: f32,
+        viewport_height: f32,
     ) {
         let n = self.search_ranges.len();
         self.search_match_virtual_ys.clear();
@@ -859,6 +953,7 @@ impl CommonMarkCache {
             }
         }
         self.last_viewport_virtual_top_y = viewport_top_y;
+        self.last_viewport_height = viewport_height;
     }
 
     /// The ordinal number of the currently active (focused) search match, if any.
@@ -1048,9 +1143,21 @@ impl CommonMarkCache {
     pub fn sync_active_match(&mut self, user_scrolled: bool) {
         if user_scrolled {
             self.search_scroll_protection = 0;
+            // The user scrolled manually, so it's safe to re-anchor
+            // active_match to the viewport again.
+            self.go_to_match_locked = false;
         }
         if self.search_scroll_protection > 0 {
             self.search_scroll_protection -= 1;
+            return;
+        }
+        // go_to_match explicitly chose a match; don't override it until the
+        // user scrolls. The 30-frame countdown above protects against drift
+        // during the scroll animation, but it can expire while the viewport
+        // is still centred on the same row as the chosen match — causing an
+        // unwanted snap back to the first match on that row. This flag keeps
+        // the lock alive past the countdown.
+        if self.go_to_match_locked {
             return;
         }
         if self.search_ranges.is_empty() || self.search_match_virtual_ys.is_empty() {
@@ -1071,10 +1178,22 @@ impl CommonMarkCache {
             .position(|&y| y >= vt)
             .unwrap_or(len - 1);
         if self.active_match != Some(nearest) {
-            self.active_match = Some(nearest);
-            self.sync_active_search_range();
-            // Do NOT call scroll_to_active_search_match: the viewport is
-            // already where the user put it.
+            // Only move away from the active match if it has actually scrolled
+            // out of the viewport. While it is still on screen the user is
+            // just panning around within the same view, and we should honour
+            // their explicit Next/Prev choice rather than snapping to the
+            // first match visible at the viewport top.
+            let active_y = self
+                .active_match
+                .and_then(|i| self.search_match_virtual_ys.get(i).copied());
+            let in_viewport =
+                active_y.is_some_and(|y| y >= vt && y < vt + self.last_viewport_height);
+            if !in_viewport {
+                self.active_match = Some(nearest);
+                self.sync_active_search_range();
+                // Do NOT call scroll_to_active_search_match: the viewport is
+                // already where the user put it.
+            }
         }
     }
 
@@ -1095,26 +1214,47 @@ impl CommonMarkCache {
             return;
         }
 
+        if user_scrolled {
+            self.search_scroll_protection = 0;
+            self.go_to_match_locked = false;
+        }
+
         let current_offset = self.viewport_start_byte_offset(egui_source_id).unwrap_or(0);
 
-        if !self.search_ranges().is_empty()
+        if !self.search_ranges.is_empty()
             && self.search_scroll_protection == 0
             && current_offset != self.last_viewport_offset
         {
-            let len = self.search_ranges().len();
+            let len = self.search_ranges.len();
             let idx = self
-                .search_ranges()
+                .search_ranges
                 .partition_point(|r| r.start < current_offset);
             let nearest = if idx > 0 {
                 idx - 1
             } else {
                 len.saturating_sub(1)
             };
-            if self.active_match() != Some(nearest) {
-                self.active_match = Some(nearest);
-                self.sync_active_search_range();
-                // Do NOT call scroll_to_active_search_match here: the
-                // viewport is already where the user put it.
+
+            if self.active_match != Some(nearest) {
+                // Only move away from the active match if it has scrolled out
+                // of the viewport. search_match_virtual_ys is now populated
+                // by the viewport-cache slice render (via update_show_viewport)
+                // so we can use the same check as sync_active_match: matches
+                // in the rendered slice have their exact pixel Y; those outside
+                // default to 0.0 and are treated as not-in-viewport.
+                let active_y = self
+                    .active_match
+                    .and_then(|i| self.search_match_virtual_ys.get(i).copied());
+                let vt = self.last_viewport_virtual_top_y;
+                let in_viewport =
+                    active_y.is_some_and(|y| y >= vt && y < vt + self.last_viewport_height);
+
+                if !in_viewport {
+                    self.active_match = Some(nearest);
+                    self.sync_active_search_range();
+                    // Do NOT call scroll_to_active_search_match here: the
+                    // viewport is already where the user put it.
+                }
             }
         }
 
@@ -1150,6 +1290,10 @@ impl CommonMarkCache {
         self.sync_active_search_range();
         self.scroll_to_active_search_match();
         self.search_scroll_protection = 30;
+        // Hold the lock until the user scrolls, so that sync_active_match
+        // cannot revert to the first match on the same visual row once the
+        // 30-frame countdown expires.
+        self.go_to_match_locked = true;
     }
 
     /// Clear the cache for all scrollable elements

--- a/egui_commonmark_backend/src/pulldown.rs
+++ b/egui_commonmark_backend/src/pulldown.rs
@@ -8,11 +8,51 @@ use std::ops::Range;
 pub struct ScrollableCache {
     pub available_size: Vec2,
     pub page_size: Option<Vec2>,
-    pub split_points: Vec<(usize, Pos2, Pos2)>,
+    /// `(event_index, vstart, vend, src_span)` for each top-level block
+    /// (paragraph/heading/code block) at a "safe" restart boundary.
+    /// `src_span` is that block's byte range in the source text, which lets
+    /// [`Self::virtual_y_for_byte_offset`] approximate the on-screen
+    /// position of arbitrary byte offsets (e.g. search matches) without
+    /// needing a fresh full render.
+    pub split_points: Vec<(usize, Pos2, Pos2, Range<usize>)>,
     /// Heading slug → virtual y (content-relative; 0 = document top).
     /// Populated during the full render; used by the viewport path to
     /// scroll to headings outside the currently rendered slice.
     pub heading_y_positions: HashMap<String, f32>,
+}
+
+impl ScrollableCache {
+    /// Approximate the virtual y (content-relative; 0 = document top) of a
+    /// byte offset in the source text, using the split points collected
+    /// during the last full render. This never requires a fresh render: at
+    /// worst (e.g. a byte offset inside a large, untracked container like a
+    /// list or table) it falls back to the nearest preceding tracked block,
+    /// which is the same granularity the viewport-slice calculation itself
+    /// already uses.
+    ///
+    /// Returns `None` only if there are no split points at all yet (i.e. no
+    /// full render has happened), in which case the caller has no choice
+    /// but to wait for one.
+    pub fn virtual_y_for_byte_offset(&self, offset: usize) -> Option<f32> {
+        if let Some((_, vstart, _, _)) = self
+            .split_points
+            .iter()
+            .find(|(_, _, _, span)| span.contains(&offset))
+        {
+            return Some(vstart.y);
+        }
+
+        // Not inside any tracked block (e.g. it's inside a list/table/
+        // blockquote, which aren't tracked individually) -- use the nearest
+        // preceding tracked block as a reasonable approximation, same as
+        // `show_scrollable`'s own slice calculation does.
+        self.split_points
+            .iter()
+            .rev()
+            .find(|(_, _, _, span)| span.start <= offset)
+            .map(|(_, vstart, _, _)| vstart.y)
+            .or_else(|| self.split_points.first().map(|(_, vstart, _, _)| vstart.y))
+    }
 }
 
 pub type EventIteratorItem<'e> = (usize, (pulldown_cmark::Event<'e>, Range<usize>));

--- a/egui_commonmark_backend/src/pulldown.rs
+++ b/egui_commonmark_backend/src/pulldown.rs
@@ -1,6 +1,7 @@
 use crate::alerts::*;
 use egui::{Pos2, Vec2};
 use pulldown_cmark::Options;
+use std::collections::HashMap;
 use std::ops::Range;
 
 #[derive(Default, Debug)]
@@ -8,6 +9,10 @@ pub struct ScrollableCache {
     pub available_size: Vec2,
     pub page_size: Option<Vec2>,
     pub split_points: Vec<(usize, Pos2, Pos2)>,
+    /// Heading slug → virtual y (content-relative; 0 = document top).
+    /// Populated during the full render; used by the viewport path to
+    /// scroll to headings outside the currently rendered slice.
+    pub heading_y_positions: HashMap<String, f32>,
 }
 
 pub type EventIteratorItem<'e> = (usize, (pulldown_cmark::Event<'e>, Range<usize>));

--- a/egui_commonmark_backend/src/pulldown.rs
+++ b/egui_commonmark_backend/src/pulldown.rs
@@ -19,6 +19,12 @@ pub struct ScrollableCache {
     /// Populated during the full render; used by the viewport path to
     /// scroll to headings outside the currently rendered slice.
     pub heading_y_positions: HashMap<String, f32>,
+    /// The most recent viewport top y (virtual, content-relative), recorded
+    /// every frame the cheap viewport-only path renders. Lets callers
+    /// approximate "what's currently visible" (e.g. to implement search
+    /// that starts from the current scroll position) via
+    /// [`Self::byte_offset_for_virtual_y`].
+    pub last_viewport_top_y: f32,
 }
 
 impl ScrollableCache {
@@ -52,6 +58,19 @@ impl ScrollableCache {
             .find(|(_, _, _, span)| span.start <= offset)
             .map(|(_, vstart, _, _)| vstart.y)
             .or_else(|| self.split_points.first().map(|(_, vstart, _, _)| vstart.y))
+    }
+
+    /// The inverse of [`Self::virtual_y_for_byte_offset`]: approximate the
+    /// source byte offset of whatever is at (or just before) the given
+    /// virtual y, using the same split points. Returns `None` only if there
+    /// are no split points at all yet.
+    pub fn byte_offset_for_virtual_y(&self, y: f32) -> Option<usize> {
+        self.split_points
+            .iter()
+            .rev()
+            .find(|(_, vstart, _, _)| vstart.y <= y)
+            .map(|(_, _, _, span)| span.start)
+            .or_else(|| self.split_points.first().map(|(_, _, _, span)| span.start))
     }
 }
 

--- a/egui_commonmark_backend/src/pulldown.rs
+++ b/egui_commonmark_backend/src/pulldown.rs
@@ -25,6 +25,10 @@ pub struct ScrollableCache {
     /// that starts from the current scroll position) via
     /// [`Self::byte_offset_for_virtual_y`].
     pub last_viewport_top_y: f32,
+    /// Height of the viewport on the most recent frame, in the same virtual
+    /// coordinate space as `last_viewport_top_y`. Together they define the
+    /// visible interval `[last_viewport_top_y, last_viewport_top_y + last_viewport_height)`.
+    pub last_viewport_height: f32,
 }
 
 impl ScrollableCache {

--- a/egui_commonmark_backend/src/search.rs
+++ b/egui_commonmark_backend/src/search.rs
@@ -1,0 +1,254 @@
+//! Utilities for highlighting search matches inside rendered markdown.
+//!
+//! The design goal here is that highlighting a search match must never change
+//! the number (or order) of widgets that get rendered. If it did, egui's
+//! auto-generated widget IDs for every widget *after* the affected text would
+//! shift whenever the search state changed, which can trigger
+//! `warn_if_rect_changes_id` false positives (same on-screen rect, different
+//! ID, because the widget counter sequence changed while the rect did not).
+//!
+//! Instead, matches are painted as backgrounds baked directly into the
+//! [`egui::text::LayoutJob`] that is already being built for a run of text
+//! (be that a body-text label or a syntax-highlighted code block). This is a
+//! purely visual change: the same widgets are created regardless of whether
+//! there are zero or a hundred matches.
+
+use egui::Color32;
+use egui::epaint::text::ByteRangeExt;
+use egui::text::{ByteIndex, LayoutJob, LayoutSection};
+use std::ops::Range;
+
+/// The default background colour for a passive (non-active) search match.
+/// Semi-transparent so that it still lets any existing syntax colour show
+/// through.
+pub fn default_match_bg() -> Color32 {
+    Color32::from_rgba_unmultiplied(255, 220, 60, 90)
+}
+
+/// The default background colour for the currently active (focused) search
+/// match.
+pub fn default_active_match_bg() -> Color32 {
+    Color32::from_rgba_unmultiplied(255, 140, 0, 150)
+}
+
+/// Given the set of global search match byte ranges (in the original source
+/// text) and the byte span of some text run within that source, compute the
+/// list of intervals *local* to that text run (0-based, relative to
+/// `src_span.start`) that should be highlighted, along with whether each one
+/// is the active match.
+///
+/// Returned intervals are sorted by start position and clamped to
+/// `0..text_len`. Empty intervals are omitted.
+pub fn search_intervals(
+    ranges: &[Range<usize>],
+    active: Option<&Range<usize>>,
+    src_span: &Range<usize>,
+    text_len: usize,
+) -> Vec<(Range<usize>, bool)> {
+    let mut intervals: Vec<(Range<usize>, bool)> = ranges
+        .iter()
+        .filter(|r| r.start < r.end && r.start < src_span.end && r.end > src_span.start)
+        .filter_map(|r| {
+            let start = r.start.saturating_sub(src_span.start).min(text_len);
+            let end = r.end.saturating_sub(src_span.start).min(text_len);
+            if start < end {
+                let is_active = active.is_some_and(|a| a.start == r.start && a.end == r.end);
+                Some((start..end, is_active))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    intervals.sort_by_key(|(r, _)| r.start);
+    intervals
+}
+
+/// Rewrite `job`'s sections so that any byte range covered by `intervals`
+/// gets its [`egui::TextFormat::background`] set to `match_bg` (or
+/// `active_bg` for the active match), splitting existing sections at the
+/// interval boundaries as needed. All other formatting (font, color,
+/// italics, etc.) is preserved unchanged.
+///
+/// Does nothing if there are no intervals.
+pub fn apply_search_highlights(
+    job: &mut LayoutJob,
+    intervals: &[(Range<usize>, bool)],
+    match_bg: Color32,
+    active_bg: Color32,
+) {
+    if intervals.is_empty() || job.sections.is_empty() {
+        return;
+    }
+
+    let text_len = job.text.len();
+    let mut new_sections = Vec::with_capacity(job.sections.len() + intervals.len() * 2);
+
+    for section in job.sections.drain(..) {
+        let sec_range = section.byte_range.as_usize();
+        let sec_start = sec_range.start.min(text_len);
+        let sec_end = sec_range.end.min(text_len);
+        if sec_start >= sec_end {
+            continue;
+        }
+
+        let mut points = vec![sec_start, sec_end];
+        for (range, _) in intervals {
+            if range.start > sec_start && range.start < sec_end {
+                points.push(range.start);
+            }
+            if range.end > sec_start && range.end < sec_end {
+                points.push(range.end);
+            }
+        }
+        points.sort_unstable();
+        points.dedup();
+
+        for pair in points.windows(2) {
+            let (start, end) = (pair[0], pair[1]);
+            if start >= end {
+                continue;
+            }
+
+            let mut format = section.format.clone();
+            if let Some((_, is_active)) = intervals
+                .iter()
+                .find(|(range, _)| range.start <= start && range.end >= end)
+            {
+                format.background = if *is_active { active_bg } else { match_bg };
+            }
+
+            let leading_space = if start == sec_start {
+                section.leading_space
+            } else {
+                0.0
+            };
+
+            new_sections.push(LayoutSection {
+                leading_space,
+                byte_range: ByteIndex(start)..ByteIndex(end),
+                format,
+            });
+        }
+    }
+
+    job.sections = new_sections;
+}
+
+/// Like [`search_intervals`], but for a code block's content, which may be
+/// assembled from multiple markdown text events (`chunks`), each with its
+/// own local byte range within `content` and source byte range in the
+/// original document.
+pub fn code_block_search_intervals(
+    chunks: &[(Range<usize>, Range<usize>)],
+    ranges: &[Range<usize>],
+    active: Option<&Range<usize>>,
+) -> Vec<(Range<usize>, bool)> {
+    let mut out = Vec::new();
+
+    for (local_chunk, src_chunk) in chunks {
+        let chunk_len = local_chunk.end.saturating_sub(local_chunk.start);
+        let sub = search_intervals(ranges, active, src_chunk, chunk_len);
+        out.extend(sub.into_iter().map(|(r, is_active)| {
+            (
+                (r.start + local_chunk.start)..(r.end + local_chunk.start),
+                is_active,
+            )
+        }));
+    }
+
+    out.sort_by_key(|(r, _)| r.start);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_overlap_yields_no_intervals() {
+        let ranges = vec![10..15];
+        let intervals = search_intervals(&ranges, None, &(0..5), 5);
+        assert!(intervals.is_empty());
+    }
+
+    #[test]
+    fn fully_contained_range_is_translated_to_local_offsets() {
+        let ranges = vec![12..15];
+        // src_span 10..20 -> local text "0123456789"
+        let intervals = search_intervals(&ranges, None, &(10..20), 10);
+        assert_eq!(intervals, vec![(2..5, false)]);
+    }
+
+    #[test]
+    fn range_overlapping_start_is_clipped() {
+        let ranges = vec![5..15];
+        let intervals = search_intervals(&ranges, None, &(10..20), 10);
+        assert_eq!(intervals, vec![(0..5, false)]);
+    }
+
+    #[test]
+    fn range_overlapping_end_is_clipped() {
+        let ranges = vec![15..25];
+        let intervals = search_intervals(&ranges, None, &(10..20), 10);
+        assert_eq!(intervals, vec![(5..10, false)]);
+    }
+
+    #[test]
+    fn active_range_is_flagged() {
+        let ranges = vec![12..15, 16..18];
+        let active = 16..18;
+        let intervals = search_intervals(&ranges, Some(&active), &(10..20), 10);
+        assert_eq!(intervals, vec![(2..5, false), (6..8, true)]);
+    }
+
+    #[test]
+    fn apply_highlights_splits_sections() {
+        let mut job = LayoutJob::default();
+        job.append("hello world", 0.0, egui::TextFormat::default());
+
+        let intervals = vec![(2..5, false)];
+        apply_search_highlights(
+            &mut job,
+            &intervals,
+            Color32::YELLOW,
+            Color32::from_rgb(255, 140, 0),
+        );
+
+        assert_eq!(job.sections.len(), 3);
+        assert_eq!(job.sections[0].byte_range.as_usize(), 0..2);
+        assert_eq!(job.sections[1].byte_range.as_usize(), 2..5);
+        assert_eq!(job.sections[2].byte_range.as_usize(), 5..11);
+        assert_eq!(job.sections[1].format.background, Color32::YELLOW);
+        assert_eq!(job.sections[0].format.background, Color32::TRANSPARENT);
+        assert_eq!(job.sections[2].format.background, Color32::TRANSPARENT);
+    }
+
+    #[test]
+    fn apply_highlights_handles_interval_spanning_multiple_sections() {
+        let mut job = LayoutJob::default();
+        job.append("foo", 0.0, egui::TextFormat::default());
+        job.append(
+            "bar",
+            0.0,
+            egui::TextFormat {
+                italics: true,
+                ..Default::default()
+            },
+        );
+
+        // Highlight "ob" which spans across the section boundary at byte 3.
+        let intervals = vec![(2..4, true)];
+        apply_search_highlights(&mut job, &intervals, Color32::YELLOW, Color32::RED);
+
+        assert_eq!(job.sections.len(), 4);
+        assert_eq!(job.sections[0].byte_range.as_usize(), 0..2); // "fo"
+        assert_eq!(job.sections[1].byte_range.as_usize(), 2..3); // "o"
+        assert_eq!(job.sections[2].byte_range.as_usize(), 3..4); // "b"
+        assert_eq!(job.sections[3].byte_range.as_usize(), 4..6); // "ar"
+        assert_eq!(job.sections[1].format.background, Color32::RED);
+        assert_eq!(job.sections[2].format.background, Color32::RED);
+        assert!(!job.sections[1].format.italics);
+        assert!(job.sections[2].format.italics);
+    }
+}

--- a/egui_commonmark_backend/src/search.rs
+++ b/egui_commonmark_backend/src/search.rs
@@ -135,11 +135,11 @@ pub fn apply_search_highlights(
     job.sections = new_sections;
 }
 
-/// Like [`search_intervals`], but for a code block's content, which may be
-/// assembled from multiple markdown text events (`chunks`), each with its
-/// own local byte range within `content` and source byte range in the
-/// original document.
-pub fn code_block_search_intervals(
+/// Like [`search_intervals`], but for content assembled from multiple
+/// markdown text events (`chunks`), each with its own local byte range
+/// within the final rendered text and source byte range in the original
+/// document. Used for both code blocks and link text.
+pub fn chunked_search_intervals(
     chunks: &[(Range<usize>, Range<usize>)],
     ranges: &[Range<usize>],
     active: Option<&Range<usize>>,

--- a/egui_commonmark_backend/src/search.rs
+++ b/egui_commonmark_backend/src/search.rs
@@ -18,17 +18,27 @@ use egui::epaint::text::ByteRangeExt;
 use egui::text::{ByteIndex, LayoutJob, LayoutSection};
 use std::ops::Range;
 
-/// The default background colour for a passive (non-active) search match.
-/// Semi-transparent so that it still lets any existing syntax colour show
-/// through.
-pub fn default_match_bg() -> Color32 {
-    Color32::from_rgba_unmultiplied(255, 220, 60, 90)
+/// The default background colour for a passive (non-active) search match:
+/// the current theme's warning colour, semi-transparent so that it still
+/// lets any existing syntax colour show through. Themed (rather than a fixed
+/// literal) so that custom [`egui::Visuals`] are respected; callers that want
+/// something else can override it (see
+/// [`crate::misc::CommonMarkOptions::search_match_bg`]).
+pub fn default_match_bg(visuals: &egui::Visuals) -> Color32 {
+    with_alpha(visuals.warn_fg_color, 90)
 }
 
 /// The default background colour for the currently active (focused) search
-/// match.
-pub fn default_active_match_bg() -> Color32 {
-    Color32::from_rgba_unmultiplied(255, 140, 0, 150)
+/// match: the current theme's error colour (more attention-grabbing than the
+/// passive match colour), semi-transparent. See
+/// [`crate::misc::CommonMarkOptions::search_active_match_bg`] for overriding
+/// it.
+pub fn default_active_match_bg(visuals: &egui::Visuals) -> Color32 {
+    with_alpha(visuals.error_fg_color, 150)
+}
+
+fn with_alpha(color: Color32, alpha: u8) -> Color32 {
+    Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), alpha)
 }
 
 /// Given the set of global search match byte ranges (in the original source

--- a/egui_commonmark_macros/src/generator.rs
+++ b/egui_commonmark_macros/src/generator.rs
@@ -842,13 +842,13 @@ impl CommonMarkViewerInternal {
             // Compile-time embedded markdown has no live search-match state to
             // track, so `chunks` is left empty and scrolling is never requested.
             stream.extend(if let Some(lang) = block.lang {
-                quote!(egui_commonmark_backend::CodeBlock {
+                quote!(let _ = egui_commonmark_backend::CodeBlock {
                     lang: Some(#lang.to_owned()), content: #content.to_owned(), chunks: Vec::new()}
-                    .end(ui, #cache, &options, max_width, false);)
+                    .end(ui, #cache, &options, max_width, false, 0.0_f32);)
             } else {
-                quote!(egui_commonmark_backend::CodeBlock {
+                quote!(let _ = egui_commonmark_backend::CodeBlock {
                     lang: None, content: #content.to_owned(), chunks: Vec::new()}
-                    .end(ui, #cache, &options, max_width, false);)
+                    .end(ui, #cache, &options, max_width, false, 0.0_f32);)
             });
 
             stream.extend(self.line.try_insert_end());

--- a/egui_commonmark_macros/src/generator.rs
+++ b/egui_commonmark_macros/src/generator.rs
@@ -608,12 +608,14 @@ impl CommonMarkViewerInternal {
                         self.code_block = Some(CodeBlock {
                             lang: Some(lang.to_string()),
                             content: "".to_string(),
+                            chunks: Vec::new(),
                         });
                     }
                     pulldown_cmark::CodeBlockKind::Indented => {
                         self.code_block = Some(CodeBlock {
                             lang: None,
                             content: "".to_string(),
+                            chunks: Vec::new(),
                         });
                     }
                 }
@@ -836,14 +838,16 @@ impl CommonMarkViewerInternal {
         if let Some(block) = self.code_block.take() {
             let content = block.content;
 
+            // Compile-time embedded markdown has no live search-match state to
+            // track, so `chunks` is left empty and scrolling is never requested.
             stream.extend(if let Some(lang) = block.lang {
                 quote!(egui_commonmark_backend::CodeBlock {
-                    lang: Some(#lang.to_owned()), content: #content.to_owned()}
-                    .end(ui, #cache, &options, max_width);)
+                    lang: Some(#lang.to_owned()), content: #content.to_owned(), chunks: Vec::new()}
+                    .end(ui, #cache, &options, max_width, false);)
             } else {
                 quote!(egui_commonmark_backend::CodeBlock {
-                    lang: None, content: #content.to_owned()}
-                    .end(ui, #cache, &options, max_width);)
+                    lang: None, content: #content.to_owned(), chunks: Vec::new()}
+                    .end(ui, #cache, &options, max_width, false);)
             });
 
             stream.extend(self.line.try_insert_end());

--- a/egui_commonmark_macros/src/generator.rs
+++ b/egui_commonmark_macros/src/generator.rs
@@ -785,8 +785,9 @@ impl CommonMarkViewerInternal {
                         quote!(
                         egui_commonmark_backend::Link {
                             destination: #destination.to_owned(),
-                            text: vec![#text_stream]
-                        }.end(ui, #cache, &options, &mut None);)
+                            text: vec![#text_stream],
+                            chunks: vec![]
+                        }.end(ui, #cache, &options, &mut None, false);)
                     }
                 } else {
                     TokenStream::new()

--- a/egui_commonmark_macros/src/generator.rs
+++ b/egui_commonmark_macros/src/generator.rs
@@ -787,7 +787,7 @@ impl CommonMarkViewerInternal {
                             destination: #destination.to_owned(),
                             text: vec![#text_stream],
                             chunks: vec![]
-                        }.end(ui, #cache, &options, &mut None, false);)
+                        }.end(ui, #cache, &options, &mut None, false, 0.0_f32);)
                     }
                 } else {
                     TokenStream::new()


### PR DESCRIPTION
This PR adds a text search facility previously attempted in the withdrawn PR 99:

1. Search-match highlighting works in both regular and viewport-caching modes and in all rendered text content including image Alt text, code blocks, alerts etc. Performance should be good in both viewing modes as care has been taken to keep overheads to a minimum. 
2. Uses a single regex mechanism under the hood to support case-sensitive or insensitive, full-word and regex search individually or in combination. The existing transitive dependency `bitflags` is also added as a direct dependency; Cargo should resolve it to the same version as the transitive dependency.
3. A `search` example is provided demonstrating the 3 search modes. For comprehensive coverage and testing of all search target types in a small footprint it includes dynamically-embedded or sampled content from various existing example markdown files borrowed from the `book` example, as well as embedding the README file but substituting a working markdown equivalent for the latter's showcase image HTML link . 
4. 3 fast unit tests added to `parsers/pulldown.rs` to verify large-document performance with `show_scrollable`.
5. Search match highlighting functions are implemented in a new backend `search` module including 7 small unit tests of the highlighting placement computation logic.
6. No ID collision issues should be encountered, because search matches no longer cause splits but are virtual in the sense that they are tracked by individually recording their byte ranges and Y positions relative to the document as a whole, and are only painted into the correct locations inside the widgets in which they occur.
7. Scrolling to the Prev/Next match is now accurate because the virtual Y position is scrolled to when the match becomes active.
 
